### PR TITLE
refactor: Regenerate A2A types from canonical schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,7 +482,18 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -732,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -747,6 +770,7 @@ dependencies = [
  "futures",
  "futures-util",
  "inference-gateway-sdk",
+ "regress",
  "reqwest",
  "serde",
  "serde_json",
@@ -947,7 +971,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1176,6 +1200,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,7 +1335,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1511,7 +1545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2000,7 +2034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.15.4",
  "indexmap",
  "semver",
 ]
@@ -2040,7 +2074,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ futures = "0.3.32"
 futures-util = "0.3.32"
 async-trait = "0.1.89"
 reqwest = { version = "0.13.3", features = ["json"] }
+regress = "0.11.1"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,12 +24,15 @@ tasks:
     cmds:
       - cargo typify schema.json -o src/a2a_types.rs
       - |
-        sed -i '1i\#![allow(clippy::uninlined_format_args)]' src/a2a_types.rs
-        sed -i '1i\#![allow(clippy::derivable_impls)]' src/a2a_types.rs
-        sed -i '1i\#![allow(clippy::enum_variant_names)]' src/a2a_types.rs
-        sed -i '1i\#![allow(clippy::large_enum_variant)]' src/a2a_types.rs
-        sed -i '1i\#![allow(clippy::unit_arg)]' src/a2a_types.rs
-        sed -i '1i\#![allow(irrefutable_let_patterns)]' src/a2a_types.rs
+        {
+          echo '#![allow(irrefutable_let_patterns)]'
+          echo '#![allow(clippy::unit_arg)]'
+          echo '#![allow(clippy::large_enum_variant)]'
+          echo '#![allow(clippy::enum_variant_names)]'
+          echo '#![allow(clippy::derivable_impls)]'
+          echo '#![allow(clippy::uninlined_format_args)]'
+          cat src/a2a_types.rs
+        } > src/a2a_types.rs.tmp && mv src/a2a_types.rs.tmp src/a2a_types.rs
       - echo "A2A types generated successfully in src/a2a_types.rs"
       - cargo fmt --all
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             info!("Agent card retrieved successfully");
             info!("Agent: {} - {}", agent_card.name, agent_card.description);
             info!(
-                "Protocol version: {}, Transport: {}",
+                "Protocol version: {}, Transport: {:?}",
                 agent_card.protocol_version, agent_card.preferred_transport
             );
         }

--- a/schema.json
+++ b/schema.json
@@ -1,110 +1,34 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "A2AError": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONParseError"
-        },
-        {
-          "$ref": "#/definitions/InvalidRequestError"
-        },
-        {
-          "$ref": "#/definitions/MethodNotFoundError"
-        },
-        {
-          "$ref": "#/definitions/InvalidParamsError"
-        },
-        {
-          "$ref": "#/definitions/InternalError"
-        },
-        {
-          "$ref": "#/definitions/TaskNotFoundError"
-        },
-        {
-          "$ref": "#/definitions/TaskNotCancelableError"
-        },
-        {
-          "$ref": "#/definitions/PushNotificationNotSupportedError"
-        },
-        {
-          "$ref": "#/definitions/UnsupportedOperationError"
-        },
-        {
-          "$ref": "#/definitions/ContentTypeNotSupportedError"
-        },
-        {
-          "$ref": "#/definitions/InvalidAgentResponseError"
-        }
-      ],
-      "description": "A discriminated union of all standard JSON-RPC and A2A-specific error types."
-    },
-    "A2ARequest": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SendMessageRequest"
-        },
-        {
-          "$ref": "#/definitions/SendStreamingMessageRequest"
-        },
-        {
-          "$ref": "#/definitions/GetTaskRequest"
-        },
-        {
-          "$ref": "#/definitions/CancelTaskRequest"
-        },
-        {
-          "$ref": "#/definitions/SetTaskPushNotificationConfigRequest"
-        },
-        {
-          "$ref": "#/definitions/GetTaskPushNotificationConfigRequest"
-        },
-        {
-          "$ref": "#/definitions/TaskResubscriptionRequest"
-        },
-        {
-          "$ref": "#/definitions/ListTaskPushNotificationConfigRequest"
-        },
-        {
-          "$ref": "#/definitions/DeleteTaskPushNotificationConfigRequest"
-        }
-      ],
-      "description": "A discriminated union representing all possible JSON-RPC 2.0 requests supported by the A2A specification."
-    },
     "APIKeySecurityScheme": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines a security scheme using an API key.",
       "properties": {
         "description": {
           "description": "An optional description for the security scheme.",
           "type": "string"
         },
-        "in": {
-          "description": "The location of the API key.",
-          "enum": [
-            "cookie",
-            "header",
-            "query"
-          ],
+        "location": {
+          "description": "The location of the API key. Valid values are \"query\", \"header\", or \"cookie\".",
           "type": "string"
         },
         "name": {
           "description": "The name of the header, query, or cookie parameter to be used.",
           "type": "string"
-        },
-        "type": {
-          "const": "apiKey",
-          "description": "The type of the security scheme. Must be 'apiKey'.",
-          "type": "string"
         }
       },
       "required": [
-        "in",
-        "name",
-        "type"
+        "location",
+        "name"
       ],
+      "title": "API Key Security Scheme",
       "type": "object"
     },
     "AgentCapabilities": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines optional capabilities supported by an agent.",
       "properties": {
         "extensions": {
@@ -123,17 +47,55 @@
           "type": "boolean"
         },
         "streaming": {
-          "description": "Indicates if the agent supports Server-Sent Events (SSE) for streaming responses.",
+          "description": "Indicates if the agent supports streaming responses.",
           "type": "boolean"
         }
       },
+      "title": "Agent Capabilities",
+      "type": "object"
+    },
+    "AgentExtension": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "A declaration of a protocol extension supported by an Agent.",
+      "properties": {
+        "description": {
+          "description": "A human-readable description of how this agent uses the extension.",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/Struct",
+          "description": "Optional, extension-specific configuration parameters."
+        },
+        "required": {
+          "description": "If true, the client must understand and comply with the extension's requirements.",
+          "type": "boolean"
+        },
+        "uri": {
+          "description": "The unique URI identifying the extension.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri",
+        "description",
+        "required"
+      ],
+      "title": "Agent Extension",
+      "type": "object"
+    },
+    "Struct": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "Struct",
       "type": "object"
     },
     "AgentCard": {
-      "description": "The AgentCard is a self-describing manifest for an agent. It provides essential\nmetadata including the agent's identity, capabilities, skills, supported\ncommunication methods, and security requirements.",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "AgentCard is a self-describing manifest for an agent. It provides essential\n metadata including the agent's identity, capabilities, skills, supported\n communication methods, and security requirements.\n Next ID: 20",
       "properties": {
         "additionalInterfaces": {
-          "description": "A list of additional supported interfaces (transport and URL combinations).\nThis allows agents to expose multiple transports, potentially at different URLs.\n\nBest practices:\n- SHOULD include all supported transports for completeness\n- SHOULD include an entry matching the main 'url' and 'preferredTransport'\n- MAY reuse URLs if multiple transports are available at the same endpoint\n- MUST accurately declare the transport available at each URL\n\nClients can select any interface from this list based on their transport capabilities\nand preferences. This enables transport negotiation and fallback scenarios.",
+          "description": "DEPRECATED: Use 'supported_interfaces' instead.",
           "items": {
             "$ref": "#/definitions/AgentInterface"
           },
@@ -141,31 +103,28 @@
         },
         "capabilities": {
           "$ref": "#/definitions/AgentCapabilities",
-          "description": "A declaration of optional capabilities supported by the agent."
+          "description": "A2A Capability set supported by the agent."
         },
         "defaultInputModes": {
-          "description": "Default set of supported input MIME types for all skills, which can be\noverridden on a per-skill basis.",
+          "description": "protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\n The set of interaction modes that the agent supports across all skills.\n This can be overridden per skill. Defined as media types.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "defaultOutputModes": {
-          "description": "Default set of supported output MIME types for all skills, which can be\noverridden on a per-skill basis.",
+          "description": "The media types supported as outputs from this agent.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "description": {
-          "description": "A human-readable description of the agent, assisting users and other agents\nin understanding its purpose.",
-          "examples": [
-            "Agent that helps users with recipes and cooking."
-          ],
+          "description": "A human-readable description of the agent, assisting users and other agents\n in understanding its purpose.\n Example: \"Agent that helps users with recipes and cooking.\"",
           "type": "string"
         },
         "documentationUrl": {
-          "description": "An optional URL to the agent's documentation.",
+          "description": "A url to provide additional documentation about the agent.",
           "type": "string"
         },
         "iconUrl": {
@@ -173,41 +132,25 @@
           "type": "string"
         },
         "name": {
-          "description": "A human-readable name for the agent.",
-          "examples": [
-            "Recipe Agent"
-          ],
+          "description": "A human readable name for the agent.\n Example: \"Recipe Agent\"",
           "type": "string"
         },
         "preferredTransport": {
-          "default": "JSONRPC",
-          "description": "The transport protocol for the preferred endpoint (the main 'url' field).\nIf not specified, defaults to 'JSONRPC'.\n\nIMPORTANT: The transport specified here MUST be available at the main 'url'.\nThis creates a binding between the main URL and its supported transport protocol.\nClients should prefer this transport and URL combination when both are supported.",
-          "examples": [
-            "JSONRPC",
-            "GRPC",
-            "HTTP+JSON"
-          ],
+          "description": "DEPRECATED: Use 'supported_interfaces' instead.",
           "type": "string"
         },
         "protocolVersion": {
-          "default": "0.2.6",
-          "description": "The version of the A2A protocol this agent supports.",
+          "description": "The version of the A2A protocol this agent supports.\n Default: \"1.0\"",
           "type": "string"
         },
         "provider": {
           "$ref": "#/definitions/AgentProvider",
-          "description": "Information about the agent's service provider."
+          "description": "The service provider of the agent."
         },
         "security": {
-          "description": "A list of security requirement objects that apply to all agent interactions. Each object\nlists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.",
+          "description": "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n Security requirements for contacting the agent.",
           "items": {
-            "additionalProperties": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "type": "object"
+            "$ref": "#/definitions/Security"
           },
           "type": "array"
         },
@@ -215,7 +158,10 @@
           "additionalProperties": {
             "$ref": "#/definitions/SecurityScheme"
           },
-          "description": "A declaration of the security schemes available to authorize requests. The key is the\nscheme name. Follows the OpenAPI 3.0 Security Scheme Object.",
+          "description": "The security scheme details used for authenticating with this agent.",
+          "propertyNames": {
+            "type": "string"
+          },
           "type": "object"
         },
         "signatures": {
@@ -226,58 +172,60 @@
           "type": "array"
         },
         "skills": {
-          "description": "The set of skills, or distinct capabilities, that the agent can perform.",
+          "description": "Skills represent an ability of an agent. It is largely\n a descriptive concept but represents a more focused set of behaviors that the\n agent is likely to succeed at.",
           "items": {
             "$ref": "#/definitions/AgentSkill"
           },
           "type": "array"
         },
-        "supportsAuthenticatedExtendedCard": {
-          "description": "If true, the agent can provide an extended agent card with additional details\nto authenticated users. Defaults to false.",
+        "supportedInterfaces": {
+          "description": "Ordered list of supported interfaces. First entry is preferred.",
+          "items": {
+            "$ref": "#/definitions/AgentInterface"
+          },
+          "type": "array"
+        },
+        "supportsExtendedAgentCard": {
+          "description": "Whether the agent supports providing an extended agent card when authenticated.",
           "type": "boolean"
         },
         "url": {
-          "description": "The preferred endpoint URL for interacting with the agent.\nThis URL MUST support the transport specified by 'preferredTransport'.",
-          "examples": [
-            "https://api.example.com/a2a/v1"
-          ],
+          "description": "DEPRECATED: Use 'supported_interfaces' instead.",
           "type": "string"
         },
         "version": {
-          "description": "The agent's own version number. The format is defined by the provider.",
-          "examples": [
-            "1.0.0"
-          ],
+          "description": "The version of the agent.\n Example: \"1.0.0\"",
           "type": "string"
         }
       },
       "required": [
+        "protocolVersion",
+        "name",
+        "description",
+        "version",
         "capabilities",
         "defaultInputModes",
         "defaultOutputModes",
-        "description",
-        "name",
-        "protocolVersion",
-        "skills",
-        "url",
-        "version"
+        "skills"
       ],
+      "title": "Agent Card",
       "type": "object"
     },
     "AgentCardSignature": {
-      "description": "AgentCardSignature represents a JWS signature of an AgentCard.\nThis follows the JSON format of an RFC 7515 JSON Web Signature (JWS).",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "AgentCardSignature represents a JWS signature of an AgentCard.\n This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).",
       "properties": {
         "header": {
-          "additionalProperties": {},
-          "description": "The unprotected JWS header values.",
-          "type": "object"
+          "$ref": "#/definitions/Struct",
+          "description": "The unprotected JWS header values."
         },
         "protected": {
-          "description": "The protected JWS header for the signature. This is a Base64url-encoded\nJSON object, as per RFC 7515.",
+          "description": "The protected JWS header for the signature. This is always a\n base64url-encoded JSON object. Required.",
           "type": "string"
         },
         "signature": {
-          "description": "The computed signature, Base64url-encoded.",
+          "description": "The computed signature, base64url-encoded. Required.",
           "type": "string"
         }
       },
@@ -285,107 +233,66 @@
         "protected",
         "signature"
       ],
-      "type": "object"
-    },
-    "AgentExtension": {
-      "description": "A declaration of a protocol extension supported by an Agent.",
-      "examples": [
-        {
-          "description": "Google OAuth 2.0 authentication",
-          "required": false,
-          "uri": "https://developers.google.com/identity/protocols/oauth2"
-        }
-      ],
-      "properties": {
-        "description": {
-          "description": "A human-readable description of how this agent uses the extension.",
-          "type": "string"
-        },
-        "params": {
-          "additionalProperties": {},
-          "description": "Optional, extension-specific configuration parameters.",
-          "type": "object"
-        },
-        "required": {
-          "description": "If true, the client must understand and comply with the extension's requirements\nto interact with the agent.",
-          "type": "boolean"
-        },
-        "uri": {
-          "description": "The unique URI identifying the extension.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "uri"
-      ],
+      "title": "Agent Card Signature",
       "type": "object"
     },
     "AgentInterface": {
-      "description": "Declares a combination of a target URL and a transport protocol for interacting with the agent.\nThis allows agents to expose the same functionality over multiple transport mechanisms.",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Declares a combination of a target URL and a transport protocol for interacting with the agent.\n This allows agents to expose the same functionality over multiple protocol binding mechanisms.",
       "properties": {
-        "transport": {
-          "description": "The transport protocol supported at this URL.",
-          "examples": [
-            "JSONRPC",
-            "GRPC",
-            "HTTP+JSON"
-          ],
+        "protocolBinding": {
+          "description": "The protocol binding supported at this URL. This is an open form string, to be\n easily extended for other protocol bindings. The core ones officially\n supported are `JSONRPC`, `GRPC` and `HTTP+JSON`.",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Tenant to be set in the request when calling the agent.",
           "type": "string"
         },
         "url": {
-          "description": "The URL where this interface is available. Must be a valid absolute HTTPS URL in production.",
-          "examples": [
-            "https://api.example.com/a2a/v1",
-            "https://grpc.example.com/a2a",
-            "https://rest.example.com/v1"
-          ],
+          "description": "The URL where this interface is available. Must be a valid absolute HTTPS URL in production.\n Example: \"https://api.example.com/a2a/v1\", \"https://grpc.example.com/a2a\"",
           "type": "string"
         }
       },
       "required": [
-        "transport",
-        "url"
+        "url",
+        "protocolBinding"
       ],
+      "title": "Agent Interface",
       "type": "object"
     },
     "AgentProvider": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Represents the service provider of an agent.",
-      "examples": [
-        {
-          "organization": "Google",
-          "url": "https://ai.google.dev"
-        }
-      ],
       "properties": {
         "organization": {
-          "description": "The name of the agent provider's organization.",
+          "description": "The name of the agent provider's organization.\n Example: \"Google\"",
           "type": "string"
         },
         "url": {
-          "description": "A URL for the agent provider's website or relevant documentation.",
+          "description": "A URL for the agent provider's website or relevant documentation.\n Example: \"https://ai.google.dev\"",
           "type": "string"
         }
       },
       "required": [
-        "organization",
-        "url"
+        "url",
+        "organization"
       ],
+      "title": "Agent Provider",
       "type": "object"
     },
     "AgentSkill": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Represents a distinct capability or function that an agent can perform.",
       "properties": {
         "description": {
-          "description": "A detailed description of the skill, intended to help clients or users\nunderstand its purpose and functionality.",
+          "description": "A detailed description of the skill.",
           "type": "string"
         },
         "examples": {
-          "description": "Example prompts or scenarios that this skill can handle. Provides a hint to\nthe client on how to use the skill.",
-          "examples": [
-            [
-              "I need a recipe for bread"
-            ]
-          ],
+          "description": "Example prompts or scenarios that this skill can handle.",
           "items": {
             "type": "string"
           },
@@ -396,7 +303,7 @@
           "type": "string"
         },
         "inputModes": {
-          "description": "The set of supported input MIME types for this skill, overriding the agent's defaults.",
+          "description": "The set of supported input media types for this skill, overriding the agent's defaults.",
           "items": {
             "type": "string"
           },
@@ -407,21 +314,21 @@
           "type": "string"
         },
         "outputModes": {
-          "description": "The set of supported output MIME types for this skill, overriding the agent's defaults.",
+          "description": "The set of supported output media types for this skill, overriding the agent's defaults.",
           "items": {
             "type": "string"
+          },
+          "type": "array"
+        },
+        "security": {
+          "description": "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n Security schemes necessary for this skill.",
+          "items": {
+            "$ref": "#/definitions/Security"
           },
           "type": "array"
         },
         "tags": {
           "description": "A set of keywords describing the skill's capabilities.",
-          "examples": [
-            [
-              "cooking",
-              "customer support",
-              "billing"
-            ]
-          ],
           "items": {
             "type": "string"
           },
@@ -429,589 +336,88 @@
         }
       },
       "required": [
-        "description",
         "id",
         "name",
+        "description",
         "tags"
       ],
-      "type": "object"
-    },
-    "Artifact": {
-      "description": "Represents a file, data structure, or other resource generated by an agent during a task.",
-      "properties": {
-        "artifactId": {
-          "description": "A unique identifier for the artifact within the scope of the task.",
-          "type": "string"
-        },
-        "description": {
-          "description": "An optional, human-readable description of the artifact.",
-          "type": "string"
-        },
-        "extensions": {
-          "description": "The URIs of extensions that are relevant to this artifact.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata for extensions. The key is an extension-specific identifier.",
-          "type": "object"
-        },
-        "name": {
-          "description": "An optional, human-readable name for the artifact.",
-          "type": "string"
-        },
-        "parts": {
-          "description": "An array of content parts that make up the artifact.",
-          "items": {
-            "$ref": "#/definitions/Part"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "artifactId",
-        "parts"
-      ],
+      "title": "Agent Skill",
       "type": "object"
     },
     "AuthorizationCodeOAuthFlow": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines configuration details for the OAuth 2.0 Authorization Code flow.",
       "properties": {
         "authorizationUrl": {
-          "description": "The authorization URL to be used for this flow.\nThis MUST be a URL and use TLS.",
+          "description": "The authorization URL to be used for this flow.",
           "type": "string"
         },
         "refreshUrl": {
-          "description": "The URL to be used for obtaining refresh tokens.\nThis MUST be a URL and use TLS.",
+          "description": "The URL to be used for obtaining refresh tokens.",
           "type": "string"
         },
         "scopes": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it.",
+          "description": "The available scopes for the OAuth2 security scheme.",
+          "propertyNames": {
+            "type": "string"
+          },
           "type": "object"
         },
         "tokenUrl": {
-          "description": "The token URL to be used for this flow.\nThis MUST be a URL and use TLS.",
+          "description": "The token URL to be used for this flow.",
           "type": "string"
         }
       },
       "required": [
         "authorizationUrl",
-        "scopes",
-        "tokenUrl"
+        "tokenUrl",
+        "scopes"
       ],
-      "type": "object"
-    },
-    "CancelTaskRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/cancel` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/cancel",
-          "description": "The method name. Must be 'tasks/cancel'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/TaskIdParams",
-          "description": "The parameters identifying the task to cancel."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "CancelTaskResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/CancelTaskSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `tasks/cancel` method."
-    },
-    "CancelTaskSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `tasks/cancel` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "$ref": "#/definitions/Task",
-          "description": "The result, containing the final state of the canceled Task object."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
+      "title": "Authorization CodeO Auth Flow",
       "type": "object"
     },
     "ClientCredentialsOAuthFlow": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines configuration details for the OAuth 2.0 Client Credentials flow.",
       "properties": {
         "refreshUrl": {
-          "description": "The URL to be used for obtaining refresh tokens. This MUST be a URL.",
+          "description": "The URL to be used for obtaining refresh tokens.",
           "type": "string"
         },
         "scopes": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it.",
+          "description": "The available scopes for the OAuth2 security scheme.",
+          "propertyNames": {
+            "type": "string"
+          },
           "type": "object"
         },
         "tokenUrl": {
-          "description": "The token URL to be used for this flow. This MUST be a URL.",
+          "description": "The token URL to be used for this flow.",
           "type": "string"
         }
       },
       "required": [
-        "scopes",
-        "tokenUrl"
+        "tokenUrl",
+        "scopes"
       ],
-      "type": "object"
-    },
-    "ContentTypeNotSupportedError": {
-      "description": "An A2A-specific error indicating an incompatibility between the requested\ncontent types and the agent's capabilities.",
-      "properties": {
-        "code": {
-          "const": -32005,
-          "description": "The error code for an unsupported content type.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Incompatible content types",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "DataPart": {
-      "description": "Represents a structured data segment (e.g., JSON) within a message or artifact.",
-      "properties": {
-        "data": {
-          "additionalProperties": {},
-          "description": "The structured data content.",
-          "type": "object"
-        },
-        "kind": {
-          "const": "data",
-          "description": "The type of this part, used as a discriminator. Always 'data'.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with this part.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "data",
-        "kind"
-      ],
-      "type": "object"
-    },
-    "DeleteTaskPushNotificationConfigParams": {
-      "description": "Defines parameters for deleting a specific push notification configuration for a task.",
-      "properties": {
-        "id": {
-          "description": "The unique identifier of the task.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with the request.",
-          "type": "object"
-        },
-        "pushNotificationConfigId": {
-          "description": "The ID of the push notification configuration to delete.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "pushNotificationConfigId"
-      ],
-      "type": "object"
-    },
-    "DeleteTaskPushNotificationConfigRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/delete` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/pushNotificationConfig/delete",
-          "description": "The method name. Must be 'tasks/pushNotificationConfig/delete'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/DeleteTaskPushNotificationConfigParams",
-          "description": "The parameters identifying the push notification configuration to delete."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "DeleteTaskPushNotificationConfigResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/DeleteTaskPushNotificationConfigSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/delete` method."
-    },
-    "DeleteTaskPushNotificationConfigSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "description": "The result is null on successful deletion.",
-          "type": "null"
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
-      "type": "object"
-    },
-    "FileBase": {
-      "description": "Defines base properties for a file.",
-      "properties": {
-        "mimeType": {
-          "description": "The MIME type of the file (e.g., \"application/pdf\").",
-          "type": "string"
-        },
-        "name": {
-          "description": "An optional name for the file (e.g., \"document.pdf\").",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "FilePart": {
-      "description": "Represents a file segment within a message or artifact. The file content can be\nprovided either directly as bytes or as a URI.",
-      "properties": {
-        "file": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FileWithBytes"
-            },
-            {
-              "$ref": "#/definitions/FileWithUri"
-            }
-          ],
-          "description": "The file content, represented as either a URI or as base64-encoded bytes."
-        },
-        "kind": {
-          "const": "file",
-          "description": "The type of this part, used as a discriminator. Always 'file'.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with this part.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "file",
-        "kind"
-      ],
-      "type": "object"
-    },
-    "FileWithBytes": {
-      "description": "Represents a file with its content provided directly as a base64-encoded string.",
-      "properties": {
-        "bytes": {
-          "description": "The base64-encoded content of the file.",
-          "type": "string"
-        },
-        "mimeType": {
-          "description": "The MIME type of the file (e.g., \"application/pdf\").",
-          "type": "string"
-        },
-        "name": {
-          "description": "An optional name for the file (e.g., \"document.pdf\").",
-          "type": "string"
-        }
-      },
-      "required": [
-        "bytes"
-      ],
-      "type": "object"
-    },
-    "FileWithUri": {
-      "description": "Represents a file with its content located at a specific URI.",
-      "properties": {
-        "mimeType": {
-          "description": "The MIME type of the file (e.g., \"application/pdf\").",
-          "type": "string"
-        },
-        "name": {
-          "description": "An optional name for the file (e.g., \"document.pdf\").",
-          "type": "string"
-        },
-        "uri": {
-          "description": "A URL pointing to the file's content.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "uri"
-      ],
-      "type": "object"
-    },
-    "GetTaskPushNotificationConfigParams": {
-      "description": "Defines parameters for fetching a specific push notification configuration for a task.",
-      "properties": {
-        "id": {
-          "description": "The unique identifier of the task.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with the request.",
-          "type": "object"
-        },
-        "pushNotificationConfigId": {
-          "description": "The ID of the push notification configuration to retrieve.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "GetTaskPushNotificationConfigRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/get` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/pushNotificationConfig/get",
-          "description": "The method name. Must be 'tasks/pushNotificationConfig/get'.",
-          "type": "string"
-        },
-        "params": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TaskIdParams"
-            },
-            {
-              "$ref": "#/definitions/GetTaskPushNotificationConfigParams"
-            }
-          ],
-          "description": "The parameters for getting a push notification configuration."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "GetTaskPushNotificationConfigResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/GetTaskPushNotificationConfigSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/get` method."
-    },
-    "GetTaskPushNotificationConfigSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/get` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "$ref": "#/definitions/TaskPushNotificationConfig",
-          "description": "The result, containing the requested push notification configuration."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
-      "type": "object"
-    },
-    "GetTaskRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/get` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/get",
-          "description": "The method name. Must be 'tasks/get'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/TaskQueryParams",
-          "description": "The parameters for querying a task."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "GetTaskResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/GetTaskSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `tasks/get` method."
-    },
-    "GetTaskSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `tasks/get` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "$ref": "#/definitions/Task",
-          "description": "The result, containing the requested Task object."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
+      "title": "Client CredentialsO Auth Flow",
       "type": "object"
     },
     "HTTPAuthSecurityScheme": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines a security scheme using HTTP authentication.",
       "properties": {
         "bearerFormat": {
-          "description": "A hint to the client to identify how the bearer token is formatted (e.g., \"JWT\").\nThis is primarily for documentation purposes.",
+          "description": "A hint to the client to identify how the bearer token is formatted (e.g., \"JWT\").\n This is primarily for documentation purposes.",
           "type": "string"
         },
         "description": {
@@ -1019,37 +425,37 @@
           "type": "string"
         },
         "scheme": {
-          "description": "The name of the HTTP Authentication scheme to be used in the Authorization header,\nas defined in RFC7235 (e.g., \"Bearer\").\nThis value should be registered in the IANA Authentication Scheme registry.",
-          "type": "string"
-        },
-        "type": {
-          "const": "http",
-          "description": "The type of the security scheme. Must be 'http'.",
+          "description": "The name of the HTTP Authentication scheme to be used in the Authorization header,\n as defined in RFC7235 (e.g., \"Bearer\").\n This value should be registered in the IANA Authentication Scheme registry.",
           "type": "string"
         }
       },
       "required": [
-        "scheme",
-        "type"
+        "scheme"
       ],
+      "title": "HTTP Auth Security Scheme",
       "type": "object"
     },
     "ImplicitOAuthFlow": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines configuration details for the OAuth 2.0 Implicit flow.",
       "properties": {
         "authorizationUrl": {
-          "description": "The authorization URL to be used for this flow. This MUST be a URL.",
+          "description": "The authorization URL to be used for this flow.",
           "type": "string"
         },
         "refreshUrl": {
-          "description": "The URL to be used for obtaining refresh tokens. This MUST be a URL.",
+          "description": "The URL to be used for obtaining refresh tokens.",
           "type": "string"
         },
         "scopes": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it.",
+          "description": "The available scopes for the OAuth2 security scheme.",
+          "propertyNames": {
+            "type": "string"
+          },
           "type": "object"
         }
       },
@@ -1057,549 +463,28 @@
         "authorizationUrl",
         "scopes"
       ],
+      "title": "ImplicitO Auth Flow",
       "type": "object"
     },
-    "InternalError": {
-      "description": "An error indicating an internal error on the server.",
+    "MutualTlsSecurityScheme": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Defines a security scheme using mTLS authentication.",
       "properties": {
-        "code": {
-          "const": -32603,
-          "description": "The error code for an internal server error.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Internal error",
-          "description": "The error message.",
+        "description": {
+          "description": "An optional description for the security scheme.",
           "type": "string"
         }
       },
       "required": [
-        "code",
-        "message"
+        "description"
       ],
-      "type": "object"
-    },
-    "InvalidAgentResponseError": {
-      "description": "An A2A-specific error indicating that the agent returned a response that\ndoes not conform to the specification for the current method.",
-      "properties": {
-        "code": {
-          "const": -32006,
-          "description": "The error code for an invalid agent response.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Invalid agent response",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "InvalidParamsError": {
-      "description": "An error indicating that the method parameters are invalid.",
-      "properties": {
-        "code": {
-          "const": -32602,
-          "description": "The error code for an invalid parameters error.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Invalid parameters",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "InvalidRequestError": {
-      "description": "An error indicating that the JSON sent is not a valid Request object.",
-      "properties": {
-        "code": {
-          "const": -32600,
-          "description": "The error code for an invalid request.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Request payload validation error",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "JSONParseError": {
-      "description": "An error indicating that the server received invalid JSON.",
-      "properties": {
-        "code": {
-          "const": -32700,
-          "description": "The error code for a JSON parse error.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Invalid JSON payload",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "JSONRPCError": {
-      "description": "Represents a JSON-RPC 2.0 Error object, included in an error response.",
-      "properties": {
-        "code": {
-          "description": "A number that indicates the error type that occurred.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "description": "A string providing a short description of the error.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "JSONRPCErrorResponse": {
-      "description": "Represents a JSON-RPC 2.0 Error Response object.",
-      "properties": {
-        "error": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JSONRPCError"
-            },
-            {
-              "$ref": "#/definitions/JSONParseError"
-            },
-            {
-              "$ref": "#/definitions/InvalidRequestError"
-            },
-            {
-              "$ref": "#/definitions/MethodNotFoundError"
-            },
-            {
-              "$ref": "#/definitions/InvalidParamsError"
-            },
-            {
-              "$ref": "#/definitions/InternalError"
-            },
-            {
-              "$ref": "#/definitions/TaskNotFoundError"
-            },
-            {
-              "$ref": "#/definitions/TaskNotCancelableError"
-            },
-            {
-              "$ref": "#/definitions/PushNotificationNotSupportedError"
-            },
-            {
-              "$ref": "#/definitions/UnsupportedOperationError"
-            },
-            {
-              "$ref": "#/definitions/ContentTypeNotSupportedError"
-            },
-            {
-              "$ref": "#/definitions/InvalidAgentResponseError"
-            }
-          ],
-          "description": "An object describing the error that occurred."
-        },
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        }
-      },
-      "required": [
-        "error",
-        "id",
-        "jsonrpc"
-      ],
-      "type": "object"
-    },
-    "JSONRPCMessage": {
-      "description": "Defines the base structure for any JSON-RPC 2.0 request, response, or notification.",
-      "properties": {
-        "id": {
-          "description": "A unique identifier established by the client. It must be a String, a Number, or null.\nThe server must reply with the same value in the response. This property is omitted for notifications.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        }
-      },
-      "required": [
-        "jsonrpc"
-      ],
-      "type": "object"
-    },
-    "JSONRPCRequest": {
-      "description": "Represents a JSON-RPC 2.0 Request object.",
-      "properties": {
-        "id": {
-          "description": "A unique identifier established by the client. It must be a String, a Number, or null.\nThe server must reply with the same value in the response. This property is omitted for notifications.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "description": "A string containing the name of the method to be invoked.",
-          "type": "string"
-        },
-        "params": {
-          "additionalProperties": {},
-          "description": "A structured value holding the parameter values to be used during the method invocation.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "jsonrpc",
-        "method"
-      ],
-      "type": "object"
-    },
-    "JSONRPCResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/SendMessageSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/SendStreamingMessageSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/GetTaskSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/CancelTaskSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/SetTaskPushNotificationConfigSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/GetTaskPushNotificationConfigSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/ListTaskPushNotificationConfigSuccessResponse"
-        },
-        {
-          "$ref": "#/definitions/DeleteTaskPushNotificationConfigSuccessResponse"
-        }
-      ],
-      "description": "A discriminated union representing all possible JSON-RPC 2.0 responses\nfor the A2A specification methods."
-    },
-    "JSONRPCSuccessResponse": {
-      "description": "Represents a successful JSON-RPC 2.0 Response object.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "description": "The value of this member is determined by the method invoked on the Server."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
-      "type": "object"
-    },
-    "ListTaskPushNotificationConfigParams": {
-      "description": "Defines parameters for listing all push notification configurations associated with a task.",
-      "properties": {
-        "id": {
-          "description": "The unique identifier of the task.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with the request.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "ListTaskPushNotificationConfigRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/list` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/pushNotificationConfig/list",
-          "description": "The method name. Must be 'tasks/pushNotificationConfig/list'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/ListTaskPushNotificationConfigParams",
-          "description": "The parameters identifying the task whose configurations are to be listed."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "ListTaskPushNotificationConfigResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/ListTaskPushNotificationConfigSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/list` method."
-    },
-    "ListTaskPushNotificationConfigSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/list` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "description": "The result, containing an array of all push notification configurations for the task.",
-          "items": {
-            "$ref": "#/definitions/TaskPushNotificationConfig"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
-      "type": "object"
-    },
-    "Message": {
-      "description": "Represents a single message in the conversation between a user and an agent.",
-      "properties": {
-        "contextId": {
-          "description": "The context identifier for this message, used to group related interactions.",
-          "type": "string"
-        },
-        "extensions": {
-          "description": "The URIs of extensions that are relevant to this message.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "kind": {
-          "const": "message",
-          "description": "The type of this object, used as a discriminator. Always 'message' for a Message.",
-          "type": "string"
-        },
-        "messageId": {
-          "description": "A unique identifier for the message, typically a UUID, generated by the sender.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata for extensions. The key is an extension-specific identifier.",
-          "type": "object"
-        },
-        "parts": {
-          "description": "An array of content parts that form the message body. A message can be\ncomposed of multiple parts of different types (e.g., text and files).",
-          "items": {
-            "$ref": "#/definitions/Part"
-          },
-          "type": "array"
-        },
-        "referenceTaskIds": {
-          "description": "A list of other task IDs that this message references for additional context.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "role": {
-          "description": "Identifies the sender of the message. `user` for the client, `agent` for the service.",
-          "enum": [
-            "agent",
-            "user"
-          ],
-          "type": "string"
-        },
-        "taskId": {
-          "description": "The identifier of the task this message is part of. Can be omitted for the first message of a new task.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "kind",
-        "messageId",
-        "parts",
-        "role"
-      ],
-      "type": "object"
-    },
-    "MessageSendConfiguration": {
-      "description": "Defines configuration options for a `message/send` or `message/stream` request.",
-      "properties": {
-        "acceptedOutputModes": {
-          "description": "A list of output MIME types the client is prepared to accept in the response.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "blocking": {
-          "description": "If true, the client will wait for the task to complete. The server may reject this if the task is long-running.",
-          "type": "boolean"
-        },
-        "historyLength": {
-          "description": "The number of most recent messages from the task's history to retrieve in the response.",
-          "type": "integer"
-        },
-        "pushNotificationConfig": {
-          "$ref": "#/definitions/PushNotificationConfig",
-          "description": "Configuration for the agent to send push notifications for updates after the initial response."
-        }
-      },
-      "type": "object"
-    },
-    "MessageSendParams": {
-      "description": "Defines the parameters for a request to send a message to an agent. This can be used\nto create a new task, continue an existing one, or restart a task.",
-      "properties": {
-        "configuration": {
-          "$ref": "#/definitions/MessageSendConfiguration",
-          "description": "Optional configuration for the send request."
-        },
-        "message": {
-          "$ref": "#/definitions/Message",
-          "description": "The message object being sent to the agent."
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata for extensions.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "message"
-      ],
-      "type": "object"
-    },
-    "MethodNotFoundError": {
-      "description": "An error indicating that the requested method does not exist or is not available.",
-      "properties": {
-        "code": {
-          "const": -32601,
-          "description": "The error code for a method not found error.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Method not found",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
+      "title": "Mutual Tls Security Scheme",
       "type": "object"
     },
     "OAuth2SecurityScheme": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines a security scheme using OAuth 2.0.",
       "properties": {
         "description": {
@@ -1610,28 +495,29 @@
           "$ref": "#/definitions/OAuthFlows",
           "description": "An object containing configuration information for the supported OAuth 2.0 flows."
         },
-        "type": {
-          "const": "oauth2",
-          "description": "The type of the security scheme. Must be 'oauth2'.",
+        "oauth2MetadataUrl": {
+          "description": "URL to the oauth2 authorization server metadata\n RFC8414 (https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.",
           "type": "string"
         }
       },
       "required": [
-        "flows",
-        "type"
+        "flows"
       ],
+      "title": "O Auth2 Security Scheme",
       "type": "object"
     },
     "OAuthFlows": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines the configuration for the supported OAuth 2.0 flows.",
       "properties": {
         "authorizationCode": {
           "$ref": "#/definitions/AuthorizationCodeOAuthFlow",
-          "description": "Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0."
+          "description": "Configuration for the OAuth Authorization Code flow."
         },
         "clientCredentials": {
           "$ref": "#/definitions/ClientCredentialsOAuthFlow",
-          "description": "Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0."
+          "description": "Configuration for the OAuth Client Credentials flow."
         },
         "implicit": {
           "$ref": "#/definitions/ImplicitOAuthFlow",
@@ -1642,9 +528,12 @@
           "description": "Configuration for the OAuth Resource Owner Password flow."
         }
       },
+      "title": "O Auth Flows",
       "type": "object"
     },
     "OpenIdConnectSecurityScheme": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines a security scheme using OpenID Connect.",
       "properties": {
         "description": {
@@ -1652,76 +541,229 @@
           "type": "string"
         },
         "openIdConnectUrl": {
-          "description": "The OpenID Connect Discovery URL for the OIDC provider's metadata.",
-          "type": "string"
-        },
-        "type": {
-          "const": "openIdConnect",
-          "description": "The type of the security scheme. Must be 'openIdConnect'.",
+          "description": "The OpenID Connect Discovery URL for the OIDC provider's metadata.\n See: https://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         }
       },
       "required": [
-        "openIdConnectUrl",
-        "type"
+        "openIdConnectUrl"
       ],
-      "type": "object"
-    },
-    "Part": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TextPart"
-        },
-        {
-          "$ref": "#/definitions/FilePart"
-        },
-        {
-          "$ref": "#/definitions/DataPart"
-        }
-      ],
-      "description": "A discriminated union representing a part of a message or artifact, which can\nbe text, a file, or structured data."
-    },
-    "PartBase": {
-      "description": "Defines base properties common to all message or artifact parts.",
-      "properties": {
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with this part.",
-          "type": "object"
-        }
-      },
+      "title": "Open Id Connect Security Scheme",
       "type": "object"
     },
     "PasswordOAuthFlow": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "description": "Defines configuration details for the OAuth 2.0 Resource Owner Password flow.",
       "properties": {
         "refreshUrl": {
-          "description": "The URL to be used for obtaining refresh tokens. This MUST be a URL.",
+          "description": "The URL to be used for obtaining refresh tokens.",
           "type": "string"
         },
         "scopes": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it.",
+          "description": "The available scopes for the OAuth2 security scheme.",
+          "propertyNames": {
+            "type": "string"
+          },
           "type": "object"
         },
         "tokenUrl": {
-          "description": "The token URL to be used for this flow. This MUST be a URL.",
+          "description": "The token URL to be used for this flow.",
           "type": "string"
         }
       },
       "required": [
-        "scopes",
-        "tokenUrl"
+        "tokenUrl",
+        "scopes"
       ],
+      "title": "PasswordO Auth Flow",
       "type": "object"
     },
-    "PushNotificationAuthenticationInfo": {
-      "description": "Defines authentication details for a push notification endpoint.",
+    "Security": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "schemes": {
+          "additionalProperties": {
+            "$ref": "#/definitions/StringList"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "title": "Security",
+      "type": "object"
+    },
+    "SecurityScheme": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Defines a security scheme that can be used to secure an agent's endpoints.\n This is a discriminated union type based on the OpenAPI 3.2 Security Scheme Object.\n See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object",
+      "properties": {
+        "apiKeySecurityScheme": {
+          "$ref": "#/definitions/APIKeySecurityScheme",
+          "description": "API key-based authentication."
+        },
+        "httpAuthSecurityScheme": {
+          "$ref": "#/definitions/HTTPAuthSecurityScheme",
+          "description": "HTTP authentication (Basic, Bearer, etc.)."
+        },
+        "mtlsSecurityScheme": {
+          "$ref": "#/definitions/MutualTlsSecurityScheme",
+          "description": "Mutual TLS authentication."
+        },
+        "oauth2SecurityScheme": {
+          "$ref": "#/definitions/OAuth2SecurityScheme",
+          "description": "OAuth 2.0 authentication."
+        },
+        "openIdConnectSecurityScheme": {
+          "$ref": "#/definitions/OpenIdConnectSecurityScheme",
+          "description": "OpenID Connect authentication."
+        }
+      },
+      "title": "Security Scheme",
+      "type": "object"
+    },
+    "StringList": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED",
+      "properties": {
+        "list": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "String List",
+      "type": "object"
+    },
+    "Artifact": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Artifacts represent task outputs.",
+      "properties": {
+        "artifactId": {
+          "description": "Unique identifier (e.g. UUID) for the artifact. It must be at least unique\n within a task.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A human readable description of the artifact, optional.",
+          "type": "string"
+        },
+        "extensions": {
+          "description": "The URIs of extensions that are present or contributed to this Artifact.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Struct",
+          "description": "Optional metadata included with the artifact."
+        },
+        "name": {
+          "description": "A human readable name for the artifact.",
+          "type": "string"
+        },
+        "parts": {
+          "description": "The content of the artifact. Must contain at least one part.",
+          "items": {
+            "$ref": "#/definitions/Part"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "artifactId",
+        "parts"
+      ],
+      "title": "Artifact",
+      "type": "object"
+    },
+    "DataPart": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "DataPart represents a structured blob.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Struct",
+          "description": "A JSON object containing arbitrary data."
+        }
+      },
+      "title": "Data Part",
+      "type": "object",
+      "required": [
+        "data"
+      ]
+    },
+    "FilePart": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "FilePart represents the different ways files can be provided. If files are\n small, directly feeding the bytes is supported via file_with_bytes. If the\n file is large, the agent should read the content as appropriate directly\n from the file_with_uri source.",
+      "properties": {
+        "fileWithBytes": {
+          "description": "The base64-encoded content of the file.",
+          "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+          "type": "string"
+        },
+        "fileWithUri": {
+          "description": "A URL pointing to the file's content.",
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the file (e.g., \"application/pdf\").",
+          "type": "string"
+        },
+        "name": {
+          "description": "An optional name for the file (e.g., \"document.pdf\").",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mediaType",
+        "name"
+      ],
+      "title": "File Part",
+      "type": "object"
+    },
+    "Part": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Part represents a container for a section of communication content.\n Parts can be purely textual, some sort of file (image, video, etc) or\n a structured data blob (i.e. JSON).",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/DataPart",
+          "description": "The structured data content."
+        },
+        "file": {
+          "$ref": "#/definitions/FilePart",
+          "description": "The file content, represented as either a URI or as base64-encoded bytes."
+        },
+        "metadata": {
+          "$ref": "#/definitions/Struct",
+          "description": "Optional metadata associated with this part."
+        },
+        "text": {
+          "description": "The string content of the text part.",
+          "type": "string"
+        }
+      },
+      "title": "Part",
+      "type": "object"
+    },
+    "AuthenticationInfo": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Defines authentication details, used for push notifications.",
       "properties": {
         "credentials": {
-          "description": "Optional credentials required by the push notification endpoint.",
+          "description": "Optional credentials",
           "type": "string"
         },
         "schemes": {
@@ -1735,372 +777,603 @@
       "required": [
         "schemes"
       ],
+      "title": "Authentication Info",
+      "type": "object"
+    },
+    "CancelTaskRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Represents a request for the `tasks/cancel` method.",
+      "properties": {
+        "name": {
+          "description": "The resource name of the task to cancel.\n Format: tasks/{task_id}",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tenant",
+        "name"
+      ],
+      "title": "Cancel Task Request",
+      "type": "object"
+    },
+    "DeleteTaskPushNotificationConfigRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Represents a request for the `tasks/pushNotificationConfig/delete` method.",
+      "properties": {
+        "name": {
+          "description": "The resource name of the config to delete.\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tenant",
+        "name"
+      ],
+      "title": "Delete Task Push Notification Config Request",
+      "type": "object"
+    },
+    "GetExtendedAgentCardRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tenant"
+      ],
+      "title": "Get Extended Agent Card Request",
+      "type": "object"
+    },
+    "GetTaskPushNotificationConfigRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The resource name of the config to retrieve.\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tenant",
+        "name"
+      ],
+      "title": "Get Task Push Notification Config Request",
+      "type": "object"
+    },
+    "GetTaskRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Represents a request for the `tasks/get` method.",
+      "properties": {
+        "historyLength": {
+          "description": "The maximum number of messages to include in the history.",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "name": {
+          "description": "The resource name of the task.\n Format: tasks/{task_id}",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Get Task Request",
+      "type": "object"
+    },
+    "ListTaskPushNotificationConfigRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "pageSize": {
+          "description": "The maximum number of configurations to return.",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "pageToken": {
+          "description": "A page token received from a previous ListTaskPushNotificationConfigRequest call.",
+          "type": "string"
+        },
+        "parent": {
+          "description": "The parent task resource.\n Format: tasks/{task_id}",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tenant",
+        "parent",
+        "pageSize",
+        "pageToken"
+      ],
+      "title": "List Task Push Notification Config Request",
+      "type": "object"
+    },
+    "ListTaskPushNotificationConfigResponse": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Represents a successful response for the `tasks/pushNotificationConfig/list`\n method.",
+      "properties": {
+        "configs": {
+          "description": "The list of push notification configurations.",
+          "items": {
+            "$ref": "#/definitions/TaskPushNotificationConfig"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page.\n If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "nextPageToken"
+      ],
+      "title": "List Task Push Notification Config Response",
       "type": "object"
     },
     "PushNotificationConfig": {
-      "description": "Defines the configuration for setting up push notifications for task updates.",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Configuration for setting up push notifications for task updates.",
       "properties": {
         "authentication": {
-          "$ref": "#/definitions/PushNotificationAuthenticationInfo",
-          "description": "Optional authentication details for the agent to use when calling the notification URL."
+          "$ref": "#/definitions/AuthenticationInfo",
+          "description": "Information about the authentication to sent with the notification"
         },
         "id": {
-          "description": "A unique ID for the push notification configuration, created by the server\nto support multiple notification callbacks.",
+          "description": "A unique identifier (e.g. UUID) for this push notification.",
           "type": "string"
         },
         "token": {
-          "description": "A unique token for this task or session to validate incoming push notifications.",
+          "description": "Token unique for this task/session",
           "type": "string"
         },
         "url": {
-          "description": "The callback URL where the agent should send push notifications.",
+          "description": "Url to send the notification too",
           "type": "string"
         }
       },
       "required": [
         "url"
       ],
+      "title": "Push Notification Config",
       "type": "object"
     },
-    "PushNotificationNotSupportedError": {
-      "description": "An A2A-specific error indicating that the agent does not support push notifications.",
+    "TaskPushNotificationConfig": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "A container associating a push notification configuration with a specific\n task.",
       "properties": {
-        "code": {
-          "const": -32003,
-          "description": "The error code for when push notifications are not supported.",
+        "name": {
+          "description": "The resource name of the config.\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}",
+          "type": "string"
+        },
+        "pushNotificationConfig": {
+          "$ref": "#/definitions/PushNotificationConfig",
+          "description": "The push notification configuration details."
+        }
+      },
+      "required": [
+        "name",
+        "pushNotificationConfig"
+      ],
+      "title": "Task Push Notification Config",
+      "type": "object"
+    },
+    "ListTasksRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Parameters for listing tasks with optional filtering criteria.",
+      "properties": {
+        "contextId": {
+          "description": "Filter tasks by context ID to get tasks from a specific conversation or session.",
+          "type": "string"
+        },
+        "historyLength": {
+          "description": "The maximum number of messages to include in each task's history.",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
           "type": "integer"
         },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
+        "includeArtifacts": {
+          "description": "Whether to include artifacts in the returned tasks.\n Defaults to false to reduce payload size.",
+          "type": "boolean"
         },
-        "message": {
-          "default": "Push Notification is not supported",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "SecurityScheme": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/APIKeySecurityScheme"
+        "lastUpdatedAfter": {
+          "description": "Filter tasks updated after this timestamp (milliseconds since epoch).\n Only tasks with a last updated time greater than or equal to this value will be returned.",
+          "type": "integer"
         },
-        {
-          "$ref": "#/definitions/HTTPAuthSecurityScheme"
+        "pageSize": {
+          "description": "Maximum number of tasks to return. Must be between 1 and 100.\n Defaults to 50 if not specified.",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
         },
-        {
-          "$ref": "#/definitions/OAuth2SecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
-        }
-      ],
-      "description": "Defines a security scheme that can be used to secure an agent's endpoints.\nThis is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object."
-    },
-    "SecuritySchemeBase": {
-      "description": "Defines base properties shared by all security scheme objects.",
-      "properties": {
-        "description": {
-          "description": "An optional description for the security scheme.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "SendMessageRequest": {
-      "description": "Represents a JSON-RPC request for the `message/send` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
+        "pageToken": {
+          "description": "Token for pagination. Use the next_page_token from a previous ListTasksResponse.",
           "type": "string"
         },
-        "method": {
-          "const": "message/send",
-          "description": "The method name. Must be 'message/send'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/MessageSendParams",
-          "description": "The parameters for sending a message."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "SendMessageResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/SendMessageSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `message/send` method."
-    },
-    "SendMessageSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `message/send` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Task"
-            },
-            {
-              "$ref": "#/definitions/Message"
-            }
+        "status": {
+          "description": "Filter tasks by their current status state.",
+          "enum": [
+            "TASK_STATE_UNSPECIFIED",
+            "TASK_STATE_SUBMITTED",
+            "TASK_STATE_WORKING",
+            "TASK_STATE_COMPLETED",
+            "TASK_STATE_FAILED",
+            "TASK_STATE_CANCELLED",
+            "TASK_STATE_INPUT_REQUIRED",
+            "TASK_STATE_REJECTED",
+            "TASK_STATE_AUTH_REQUIRED"
           ],
-          "description": "The result, which can be a direct reply Message or the initial Task object."
+          "title": "Task State",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
         }
       },
       "required": [
-        "id",
-        "jsonrpc",
-        "result"
+        "tenant",
+        "contextId",
+        "status",
+        "pageToken",
+        "lastUpdatedAfter"
       ],
+      "title": "List Tasks Request",
       "type": "object"
     },
-    "SendStreamingMessageRequest": {
-      "description": "Represents a JSON-RPC request for the `message/stream` method.",
+    "ListTasksResponse": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Result object for tasks/list method containing an array of tasks and pagination information.",
       "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
+        "nextPageToken": {
+          "description": "Token for retrieving the next page. Empty string if no more results.",
           "type": "string"
         },
-        "method": {
-          "const": "message/stream",
-          "description": "The method name. Must be 'message/stream'.",
-          "type": "string"
+        "pageSize": {
+          "description": "The size of page requested.",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
         },
-        "params": {
-          "$ref": "#/definitions/MessageSendParams",
-          "description": "The parameters for sending a message."
+        "tasks": {
+          "description": "Array of tasks matching the specified criteria.",
+          "items": {
+            "$ref": "#/definitions/Task"
+          },
+          "type": "array"
+        },
+        "totalSize": {
+          "description": "Total number of tasks available (before pagination).",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
         }
       },
       "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
+        "tasks",
+        "nextPageToken",
+        "pageSize",
+        "totalSize"
       ],
+      "title": "List Tasks Response",
       "type": "object"
     },
-    "SendStreamingMessageResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/SendStreamingMessageSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `message/stream` method."
-    },
-    "SendStreamingMessageSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `message/stream` method.\nThe server may send multiple response objects for a single request.",
+    "Message": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Message is one unit of communication between client and server. It is\n associated with a context and optionally a task. Since the server is\n responsible for the context definition, it must always provide a context_id\n in its messages. The client can optionally provide the context_id if it\n knows the context to associate the message to. Similarly for task_id,\n except the server decides if a task is created and whether to include the\n task_id.",
       "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
+        "contextId": {
+          "description": "The context id of the message. This is optional and if set, the message\n will be associated with the given context.",
           "type": "string"
         },
-        "result": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Task"
-            },
-            {
-              "$ref": "#/definitions/Message"
-            },
-            {
-              "$ref": "#/definitions/TaskStatusUpdateEvent"
-            },
-            {
-              "$ref": "#/definitions/TaskArtifactUpdateEvent"
-            }
+        "extensions": {
+          "description": "The URIs of extensions that are present or contributed to this Message.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "messageId": {
+          "description": "The unique identifier (e.g. UUID) of the message. This is required and\n created by the message creator.",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Struct",
+          "description": "protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\n Any optional metadata to provide along with the message."
+        },
+        "parts": {
+          "description": "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n Parts is the container of the message content.",
+          "items": {
+            "$ref": "#/definitions/Part"
+          },
+          "type": "array"
+        },
+        "referenceTaskIds": {
+          "description": "A list of task IDs that this message references for additional context.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "role": {
+          "description": "Identifies the sender of the message.",
+          "enum": [
+            "ROLE_UNSPECIFIED",
+            "ROLE_USER",
+            "ROLE_AGENT"
           ],
-          "description": "The result, which can be a Message, Task, or a streaming update event."
+          "title": "Role",
+          "type": "string"
+        },
+        "taskId": {
+          "description": "The task id of the message. This is optional and if set, the message\n will be associated with the given task.",
+          "type": "string"
         }
       },
       "required": [
-        "id",
-        "jsonrpc",
-        "result"
+        "messageId",
+        "role",
+        "parts"
       ],
-      "type": "object"
-    },
-    "SetTaskPushNotificationConfigRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/set` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/pushNotificationConfig/set",
-          "description": "The method name. Must be 'tasks/pushNotificationConfig/set'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/TaskPushNotificationConfig",
-          "description": "The parameters for setting the push notification configuration."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "SetTaskPushNotificationConfigResponse": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/JSONRPCErrorResponse"
-        },
-        {
-          "$ref": "#/definitions/SetTaskPushNotificationConfigSuccessResponse"
-        }
-      ],
-      "description": "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/set` method."
-    },
-    "SetTaskPushNotificationConfigSuccessResponse": {
-      "description": "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/set` method.",
-      "properties": {
-        "id": {
-          "description": "The identifier established by the client.",
-          "type": [
-            "string",
-            "integer",
-            "null"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "result": {
-          "$ref": "#/definitions/TaskPushNotificationConfig",
-          "description": "The result, containing the configured push notification settings."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
+      "title": "Message",
       "type": "object"
     },
     "Task": {
-      "description": "Represents a single, stateful operation or conversation between a client and an agent.",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Task is the core unit of action for A2A. It has a current status\n and when results are created for the task they are stored in the\n artifact. If there are multiple turns for a task, these are stored in\n history.",
       "properties": {
         "artifacts": {
-          "description": "A collection of artifacts generated by the agent during the execution of the task.",
+          "description": "A set of output artifacts for a Task.",
           "items": {
             "$ref": "#/definitions/Artifact"
           },
           "type": "array"
         },
         "contextId": {
-          "description": "A server-generated identifier for maintaining context across multiple related tasks or interactions.",
+          "description": "Unique identifier (e.g. UUID) for the contextual collection of interactions\n (tasks and messages). Created by the A2A server.",
           "type": "string"
         },
         "history": {
-          "description": "An array of messages exchanged during the task, representing the conversation history.",
+          "description": "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n The history of interactions from a task.",
           "items": {
             "$ref": "#/definitions/Message"
           },
           "type": "array"
         },
         "id": {
-          "description": "A unique identifier for the task, generated by the client for a new task or provided by the agent.",
-          "type": "string"
-        },
-        "kind": {
-          "const": "task",
-          "description": "The type of this object, used as a discriminator. Always 'task' for a Task.",
+          "description": "Unique identifier (e.g. UUID) for the task, generated by the server for a\n new task.",
           "type": "string"
         },
         "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata for extensions. The key is an extension-specific identifier.",
-          "type": "object"
+          "$ref": "#/definitions/Struct",
+          "description": "protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\n A key/value object to store custom metadata about a task."
         },
         "status": {
           "$ref": "#/definitions/TaskStatus",
-          "description": "The current status of the task, including its state and a descriptive message."
+          "description": "The current status of a Task, including state and a message."
         }
       },
       "required": [
-        "contextId",
         "id",
-        "kind",
+        "contextId",
         "status"
       ],
+      "title": "Task",
+      "type": "object"
+    },
+    "TaskStatus": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "A container for the status of a task",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/Message",
+          "description": "A message associated with the status."
+        },
+        "state": {
+          "description": "The current state of this task.",
+          "enum": [
+            "TASK_STATE_UNSPECIFIED",
+            "TASK_STATE_SUBMITTED",
+            "TASK_STATE_WORKING",
+            "TASK_STATE_COMPLETED",
+            "TASK_STATE_FAILED",
+            "TASK_STATE_CANCELLED",
+            "TASK_STATE_INPUT_REQUIRED",
+            "TASK_STATE_REJECTED",
+            "TASK_STATE_AUTH_REQUIRED"
+          ],
+          "title": "Task State",
+          "type": "string"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "ISO 8601 Timestamp when the status was recorded.\n Example: \"2023-10-27T10:00:00Z\""
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "title": "Task Status",
+      "type": "object"
+    },
+    "Timestamp": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "date-time",
+      "title": "Timestamp",
+      "type": "string"
+    },
+    "SendMessageConfiguration": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Configuration of a send message request.",
+      "properties": {
+        "acceptedOutputModes": {
+          "description": "A list of media types the client is prepared to accept for response parts. Agents SHOULD use this to tailor their output.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocking": {
+          "description": "If true, the operation waits until the task reaches a terminal state before returning. Default is false.",
+          "type": "boolean"
+        },
+        "historyLength": {
+          "description": "The maximum number of messages to include in the history.",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "pushNotificationConfig": {
+          "$ref": "#/definitions/PushNotificationConfig",
+          "description": "Configuration for the agent to send push notifications for task updates."
+        }
+      },
+      "required": [
+        "blocking"
+      ],
+      "title": "Send Message Configuration",
+      "type": "object"
+    },
+    "SendMessageRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "/////////// Request Messages ///////////\n Represents a request for the `message/send` method.",
+      "properties": {
+        "configuration": {
+          "$ref": "#/definitions/SendMessageConfiguration",
+          "description": "Configuration for the send request."
+        },
+        "message": {
+          "$ref": "#/definitions/Message",
+          "description": "The message to send to the agent."
+        },
+        "metadata": {
+          "$ref": "#/definitions/Struct",
+          "description": "A flexible key-value map for passing additional context or parameters."
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tenant"
+      ],
+      "title": "Send Message Request",
+      "type": "object"
+    },
+    "SendMessageResponse": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "////// Response Messages ///////////",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/Message"
+        },
+        "task": {
+          "$ref": "#/definitions/Task"
+        }
+      },
+      "title": "Send Message Response",
+      "type": "object"
+    },
+    "SetTaskPushNotificationConfigRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "Represents a request for the `tasks/pushNotificationConfig/set` method.",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/TaskPushNotificationConfig",
+          "description": "The configuration to create."
+        },
+        "configId": {
+          "description": "The ID for the new config.",
+          "type": "string"
+        },
+        "parent": {
+          "description": "The parent task resource for this config.\n Format: tasks/{task_id}",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "parent",
+        "configId",
+        "config"
+      ],
+      "title": "Set Task Push Notification Config Request",
+      "type": "object"
+    },
+    "StreamResponse": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "A wrapper object used in streaming operations to encapsulate different types of response data.",
+      "properties": {
+        "artifactUpdate": {
+          "$ref": "#/definitions/TaskArtifactUpdateEvent",
+          "description": "An event indicating a task artifact update."
+        },
+        "message": {
+          "$ref": "#/definitions/Message",
+          "description": "A Message object containing a message from the agent."
+        },
+        "statusUpdate": {
+          "$ref": "#/definitions/TaskStatusUpdateEvent",
+          "description": "An event indicating a task status update."
+        },
+        "task": {
+          "$ref": "#/definitions/Task",
+          "description": "A Task object containing the current state of the task."
+        }
+      },
+      "title": "Stream Response",
       "type": "object"
     },
     "TaskArtifactUpdateEvent": {
-      "description": "An event sent by the agent to notify the client that an artifact has been\ngenerated or updated. This is typically used in streaming models.",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "TaskArtifactUpdateEvent represents a task delta where an artifact has\n been generated.",
       "properties": {
         "append": {
-          "description": "If true, the content of this artifact should be appended to a previously sent artifact with the same ID.",
+          "description": "If true, the content of this artifact should be appended to a previously\n sent artifact with the same ID.",
           "type": "boolean"
         },
         "artifact": {
@@ -2108,12 +1381,7 @@
           "description": "The artifact that was generated or updated."
         },
         "contextId": {
-          "description": "The context ID associated with the task.",
-          "type": "string"
-        },
-        "kind": {
-          "const": "artifact-update",
-          "description": "The type of this event, used as a discriminator. Always 'artifact-update'.",
+          "description": "The id of the context that this task belongs to.",
           "type": "string"
         },
         "lastChunk": {
@@ -2121,292 +1389,75 @@
           "type": "boolean"
         },
         "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata for extensions.",
-          "type": "object"
+          "$ref": "#/definitions/Struct",
+          "description": "Optional metadata associated with the artifact update."
         },
         "taskId": {
-          "description": "The ID of the task this artifact belongs to.",
+          "description": "The id of the task for this artifact.",
           "type": "string"
         }
       },
       "required": [
-        "artifact",
+        "taskId",
         "contextId",
-        "kind",
-        "taskId"
+        "artifact"
       ],
-      "type": "object"
-    },
-    "TaskIdParams": {
-      "description": "Defines parameters containing a task ID, used for simple task operations.",
-      "properties": {
-        "id": {
-          "description": "The unique identifier of the task.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with the request.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "TaskNotCancelableError": {
-      "description": "An A2A-specific error indicating that the task is in a state where it cannot be canceled.",
-      "properties": {
-        "code": {
-          "const": -32002,
-          "description": "The error code for a task that cannot be canceled.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Task cannot be canceled",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "TaskNotFoundError": {
-      "description": "An A2A-specific error indicating that the requested task ID was not found.",
-      "properties": {
-        "code": {
-          "const": -32001,
-          "description": "The error code for a task not found error.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "Task not found",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
-      "type": "object"
-    },
-    "TaskPushNotificationConfig": {
-      "description": "A container associating a push notification configuration with a specific task.",
-      "properties": {
-        "pushNotificationConfig": {
-          "$ref": "#/definitions/PushNotificationConfig",
-          "description": "The push notification configuration for this task."
-        },
-        "taskId": {
-          "description": "The ID of the task.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "pushNotificationConfig",
-        "taskId"
-      ],
-      "type": "object"
-    },
-    "TaskQueryParams": {
-      "description": "Defines parameters for querying a task, with an option to limit history length.",
-      "properties": {
-        "historyLength": {
-          "description": "The number of most recent messages from the task's history to retrieve.",
-          "type": "integer"
-        },
-        "id": {
-          "description": "The unique identifier of the task.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with the request.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "TaskResubscriptionRequest": {
-      "description": "Represents a JSON-RPC request for the `tasks/resubscribe` method, used to resume a streaming connection.",
-      "properties": {
-        "id": {
-          "description": "The identifier for this request.",
-          "type": [
-            "string",
-            "integer"
-          ]
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "The version of the JSON-RPC protocol. MUST be exactly \"2.0\".",
-          "type": "string"
-        },
-        "method": {
-          "const": "tasks/resubscribe",
-          "description": "The method name. Must be 'tasks/resubscribe'.",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/definitions/TaskIdParams",
-          "description": "The parameters identifying the task to resubscribe to."
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "method",
-        "params"
-      ],
-      "type": "object"
-    },
-    "TaskState": {
-      "description": "Defines the lifecycle states of a Task.",
-      "enum": [
-        "submitted",
-        "working",
-        "input-required",
-        "completed",
-        "canceled",
-        "failed",
-        "rejected",
-        "auth-required",
-        "unknown"
-      ],
-      "type": "string"
-    },
-    "TaskStatus": {
-      "description": "Represents the status of a task at a specific point in time.",
-      "properties": {
-        "message": {
-          "$ref": "#/definitions/Message",
-          "description": "An optional, human-readable message providing more details about the current status."
-        },
-        "state": {
-          "$ref": "#/definitions/TaskState",
-          "description": "The current state of the task's lifecycle."
-        },
-        "timestamp": {
-          "description": "An ISO 8601 datetime string indicating when this status was recorded.",
-          "examples": [
-            "2023-10-27T10:00:00Z"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "state"
-      ],
+      "title": "Task Artifact Update Event",
       "type": "object"
     },
     "TaskStatusUpdateEvent": {
-      "description": "An event sent by the agent to notify the client of a change in a task's status.\nThis is typically used in streaming or subscription models.",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "description": "An event sent by the agent to notify the client of a change in a task's\n status.",
       "properties": {
         "contextId": {
-          "description": "The context ID associated with the task.",
+          "description": "The id of the context that the task belongs to",
           "type": "string"
         },
         "final": {
           "description": "If true, this is the final event in the stream for this interaction.",
           "type": "boolean"
         },
-        "kind": {
-          "const": "status-update",
-          "description": "The type of this event, used as a discriminator. Always 'status-update'.",
-          "type": "string"
-        },
         "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata for extensions.",
-          "type": "object"
+          "$ref": "#/definitions/Struct",
+          "description": "Optional metadata to associate with the task update."
         },
         "status": {
           "$ref": "#/definitions/TaskStatus",
           "description": "The new status of the task."
         },
         "taskId": {
-          "description": "The ID of the task that was updated.",
+          "description": "The id of the task that is changed",
           "type": "string"
         }
       },
       "required": [
+        "taskId",
         "contextId",
-        "final",
-        "kind",
         "status",
-        "taskId"
+        "final"
       ],
+      "title": "Task Status Update Event",
       "type": "object"
     },
-    "TextPart": {
-      "description": "Represents a text segment within a message or artifact.",
+    "SubscribeToTaskRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
-        "kind": {
-          "const": "text",
-          "description": "The type of this part, used as a discriminator. Always 'text'.",
+        "name": {
+          "description": "The resource name of the task to subscribe to.\n Format: tasks/{task_id}",
           "type": "string"
         },
-        "metadata": {
-          "additionalProperties": {},
-          "description": "Optional metadata associated with this part.",
-          "type": "object"
-        },
-        "text": {
-          "description": "The string content of the text part.",
+        "tenant": {
+          "description": "Optional tenant, provided as a path parameter.",
           "type": "string"
         }
       },
       "required": [
-        "kind",
-        "text"
+        "tenant",
+        "name"
       ],
-      "type": "object"
-    },
-    "TransportProtocol": {
-      "description": "Supported A2A transport protocols.",
-      "enum": [
-        "JSONRPC",
-        "GRPC",
-        "HTTP+JSON"
-      ],
-      "type": "string"
-    },
-    "UnsupportedOperationError": {
-      "description": "An A2A-specific error indicating that the requested operation is not supported by the agent.",
-      "properties": {
-        "code": {
-          "const": -32004,
-          "description": "The error code for an unsupported operation.",
-          "type": "integer"
-        },
-        "data": {
-          "description": "A primitive or structured value containing additional information about the error.\nThis may be omitted."
-        },
-        "message": {
-          "default": "This operation is not supported",
-          "description": "The error message.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ],
+      "title": "Subscribe To Task Request",
       "type": "object"
     }
   }

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,57 +1,27 @@
 $schema: http://json-schema.org/draft-07/schema#
 definitions:
-  A2AError:
-    anyOf:
-      - $ref: '#/definitions/JSONParseError'
-      - $ref: '#/definitions/InvalidRequestError'
-      - $ref: '#/definitions/MethodNotFoundError'
-      - $ref: '#/definitions/InvalidParamsError'
-      - $ref: '#/definitions/InternalError'
-      - $ref: '#/definitions/TaskNotFoundError'
-      - $ref: '#/definitions/TaskNotCancelableError'
-      - $ref: '#/definitions/PushNotificationNotSupportedError'
-      - $ref: '#/definitions/UnsupportedOperationError'
-      - $ref: '#/definitions/ContentTypeNotSupportedError'
-      - $ref: '#/definitions/InvalidAgentResponseError'
-    description: A discriminated union of all standard JSON-RPC and A2A-specific error types.
-  A2ARequest:
-    anyOf:
-      - $ref: '#/definitions/SendMessageRequest'
-      - $ref: '#/definitions/SendStreamingMessageRequest'
-      - $ref: '#/definitions/GetTaskRequest'
-      - $ref: '#/definitions/CancelTaskRequest'
-      - $ref: '#/definitions/SetTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/GetTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/TaskResubscriptionRequest'
-      - $ref: '#/definitions/ListTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/DeleteTaskPushNotificationConfigRequest'
-    description: A discriminated union representing all possible JSON-RPC 2.0 requests supported by the A2A specification.
   APIKeySecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using an API key.
     properties:
       description:
         description: An optional description for the security scheme.
         type: string
-      in:
-        description: The location of the API key.
-        enum:
-          - cookie
-          - header
-          - query
+      location:
+        description: The location of the API key. Valid values are "query", "header", or "cookie".
         type: string
       name:
         description: The name of the header, query, or cookie parameter to be used.
         type: string
-      type:
-        const: apiKey
-        description: The type of the security scheme. Must be 'apiKey'.
-        type: string
     required:
-      - in
+      - location
       - name
-      - type
+    title: API Key Security Scheme
     type: object
   AgentCapabilities:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines optional capabilities supported by an agent.
     properties:
       extensions:
@@ -66,104 +36,108 @@ definitions:
         description: Indicates if the agent provides a history of state transitions for a task.
         type: boolean
       streaming:
-        description: Indicates if the agent supports Server-Sent Events (SSE) for streaming responses.
+        description: Indicates if the agent supports streaming responses.
         type: boolean
+    title: Agent Capabilities
+    type: object
+  AgentExtension:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: A declaration of a protocol extension supported by an Agent.
+    properties:
+      description:
+        description: A human-readable description of how this agent uses the extension.
+        type: string
+      params:
+        $ref: '#/definitions/Struct'
+        description: Optional, extension-specific configuration parameters.
+      required:
+        description: If true, the client must understand and comply with the extension's requirements.
+        type: boolean
+      uri:
+        description: The unique URI identifying the extension.
+        type: string
+    required:
+      - uri
+      - description
+      - required
+    title: Agent Extension
+    type: object
+  Struct:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    title: Struct
     type: object
   AgentCard:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      The AgentCard is a self-describing manifest for an agent. It provides essential
-      metadata including the agent's identity, capabilities, skills, supported
-      communication methods, and security requirements.
+      AgentCard is a self-describing manifest for an agent. It provides essential
+       metadata including the agent's identity, capabilities, skills, supported
+       communication methods, and security requirements.
+       Next ID: 20
     properties:
       additionalInterfaces:
-        description: |-
-          A list of additional supported interfaces (transport and URL combinations).
-          This allows agents to expose multiple transports, potentially at different URLs.
-
-          Best practices:
-          - SHOULD include all supported transports for completeness
-          - SHOULD include an entry matching the main 'url' and 'preferredTransport'
-          - MAY reuse URLs if multiple transports are available at the same endpoint
-          - MUST accurately declare the transport available at each URL
-
-          Clients can select any interface from this list based on their transport capabilities
-          and preferences. This enables transport negotiation and fallback scenarios.
+        description: 'DEPRECATED: Use ''supported_interfaces'' instead.'
         items:
           $ref: '#/definitions/AgentInterface'
         type: array
       capabilities:
         $ref: '#/definitions/AgentCapabilities'
-        description: A declaration of optional capabilities supported by the agent.
+        description: A2A Capability set supported by the agent.
       defaultInputModes:
         description: |-
-          Default set of supported input MIME types for all skills, which can be
-          overridden on a per-skill basis.
+          protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+           The set of interaction modes that the agent supports across all skills.
+           This can be overridden per skill. Defined as media types.
         items:
           type: string
         type: array
       defaultOutputModes:
-        description: |-
-          Default set of supported output MIME types for all skills, which can be
-          overridden on a per-skill basis.
+        description: The media types supported as outputs from this agent.
         items:
           type: string
         type: array
       description:
         description: |-
           A human-readable description of the agent, assisting users and other agents
-          in understanding its purpose.
-        examples:
-          - Agent that helps users with recipes and cooking.
+           in understanding its purpose.
+           Example: "Agent that helps users with recipes and cooking."
         type: string
       documentationUrl:
-        description: An optional URL to the agent's documentation.
+        description: A url to provide additional documentation about the agent.
         type: string
       iconUrl:
         description: An optional URL to an icon for the agent.
         type: string
       name:
-        description: A human-readable name for the agent.
-        examples:
-          - Recipe Agent
+        description: |-
+          A human readable name for the agent.
+           Example: "Recipe Agent"
         type: string
       preferredTransport:
-        default: JSONRPC
-        description: |-
-          The transport protocol for the preferred endpoint (the main 'url' field).
-          If not specified, defaults to 'JSONRPC'.
-
-          IMPORTANT: The transport specified here MUST be available at the main 'url'.
-          This creates a binding between the main URL and its supported transport protocol.
-          Clients should prefer this transport and URL combination when both are supported.
-        examples:
-          - JSONRPC
-          - GRPC
-          - HTTP+JSON
+        description: 'DEPRECATED: Use ''supported_interfaces'' instead.'
         type: string
       protocolVersion:
-        default: 0.2.6
-        description: The version of the A2A protocol this agent supports.
+        description: |-
+          The version of the A2A protocol this agent supports.
+           Default: "1.0"
         type: string
       provider:
         $ref: '#/definitions/AgentProvider'
-        description: Information about the agent's service provider.
+        description: The service provider of the agent.
       security:
         description: |-
-          A list of security requirement objects that apply to all agent interactions. Each object
-          lists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           Security requirements for contacting the agent.
         items:
-          additionalProperties:
-            items:
-              type: string
-            type: array
-          type: object
+          $ref: '#/definitions/Security'
         type: array
       securitySchemes:
         additionalProperties:
           $ref: '#/definitions/SecurityScheme'
-        description: |-
-          A declaration of the security schemes available to authorize requests. The key is the
-          scheme name. Follows the OpenAPI 3.0 Security Scheme Object.
+        description: The security scheme details used for authenticating with this agent.
+        propertyNames:
+          type: string
         type: object
       signatures:
         description: JSON Web Signatures computed for this AgentCard.
@@ -171,137 +145,119 @@ definitions:
           $ref: '#/definitions/AgentCardSignature'
         type: array
       skills:
-        description: The set of skills, or distinct capabilities, that the agent can perform.
+        description: |-
+          Skills represent an ability of an agent. It is largely
+           a descriptive concept but represents a more focused set of behaviors that the
+           agent is likely to succeed at.
         items:
           $ref: '#/definitions/AgentSkill'
         type: array
-      supportsAuthenticatedExtendedCard:
-        description: |-
-          If true, the agent can provide an extended agent card with additional details
-          to authenticated users. Defaults to false.
+      supportedInterfaces:
+        description: Ordered list of supported interfaces. First entry is preferred.
+        items:
+          $ref: '#/definitions/AgentInterface'
+        type: array
+      supportsExtendedAgentCard:
+        description: Whether the agent supports providing an extended agent card when authenticated.
         type: boolean
       url:
-        description: |-
-          The preferred endpoint URL for interacting with the agent.
-          This URL MUST support the transport specified by 'preferredTransport'.
-        examples:
-          - https://api.example.com/a2a/v1
+        description: 'DEPRECATED: Use ''supported_interfaces'' instead.'
         type: string
       version:
-        description: The agent's own version number. The format is defined by the provider.
-        examples:
-          - 1.0.0
+        description: |-
+          The version of the agent.
+           Example: "1.0.0"
         type: string
     required:
+      - protocolVersion
+      - name
+      - description
+      - version
       - capabilities
       - defaultInputModes
       - defaultOutputModes
-      - description
-      - name
-      - protocolVersion
       - skills
-      - url
-      - version
+    title: Agent Card
     type: object
   AgentCardSignature:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
       AgentCardSignature represents a JWS signature of an AgentCard.
-      This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).
+       This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).
     properties:
       header:
-        additionalProperties: {}
+        $ref: '#/definitions/Struct'
         description: The unprotected JWS header values.
-        type: object
       protected:
         description: |-
-          The protected JWS header for the signature. This is a Base64url-encoded
-          JSON object, as per RFC 7515.
+          The protected JWS header for the signature. This is always a
+           base64url-encoded JSON object. Required.
         type: string
       signature:
-        description: The computed signature, Base64url-encoded.
+        description: The computed signature, base64url-encoded. Required.
         type: string
     required:
       - protected
       - signature
-    type: object
-  AgentExtension:
-    description: A declaration of a protocol extension supported by an Agent.
-    examples:
-      - description: Google OAuth 2.0 authentication
-        required: false
-        uri: https://developers.google.com/identity/protocols/oauth2
-    properties:
-      description:
-        description: A human-readable description of how this agent uses the extension.
-        type: string
-      params:
-        additionalProperties: {}
-        description: Optional, extension-specific configuration parameters.
-        type: object
-      required:
-        description: |-
-          If true, the client must understand and comply with the extension's requirements
-          to interact with the agent.
-        type: boolean
-      uri:
-        description: The unique URI identifying the extension.
-        type: string
-    required:
-      - uri
+    title: Agent Card Signature
     type: object
   AgentInterface:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
       Declares a combination of a target URL and a transport protocol for interacting with the agent.
-      This allows agents to expose the same functionality over multiple transport mechanisms.
+       This allows agents to expose the same functionality over multiple protocol binding mechanisms.
     properties:
-      transport:
-        description: The transport protocol supported at this URL.
-        examples:
-          - JSONRPC
-          - GRPC
-          - HTTP+JSON
+      protocolBinding:
+        description: |-
+          The protocol binding supported at this URL. This is an open form string, to be
+           easily extended for other protocol bindings. The core ones officially
+           supported are `JSONRPC`, `GRPC` and `HTTP+JSON`.
+        type: string
+      tenant:
+        description: Tenant to be set in the request when calling the agent.
         type: string
       url:
-        description: The URL where this interface is available. Must be a valid absolute HTTPS URL in production.
-        examples:
-          - https://api.example.com/a2a/v1
-          - https://grpc.example.com/a2a
-          - https://rest.example.com/v1
+        description: |-
+          The URL where this interface is available. Must be a valid absolute HTTPS URL in production.
+           Example: "https://api.example.com/a2a/v1", "https://grpc.example.com/a2a"
         type: string
     required:
-      - transport
       - url
+      - protocolBinding
+    title: Agent Interface
     type: object
   AgentProvider:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Represents the service provider of an agent.
-    examples:
-      - organization: Google
-        url: https://ai.google.dev
     properties:
       organization:
-        description: The name of the agent provider's organization.
+        description: |-
+          The name of the agent provider's organization.
+           Example: "Google"
         type: string
       url:
-        description: A URL for the agent provider's website or relevant documentation.
+        description: |-
+          A URL for the agent provider's website or relevant documentation.
+           Example: "https://ai.google.dev"
         type: string
     required:
-      - organization
       - url
+      - organization
+    title: Agent Provider
     type: object
   AgentSkill:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Represents a distinct capability or function that an agent can perform.
     properties:
       description:
-        description: |-
-          A detailed description of the skill, intended to help clients or users
-          understand its purpose and functionality.
+        description: A detailed description of the skill.
         type: string
       examples:
-        description: |-
-          Example prompts or scenarios that this skill can handle. Provides a hint to
-          the client on how to use the skill.
-        examples:
-          - - I need a recipe for bread
+        description: Example prompts or scenarios that this skill can handle.
         items:
           type: string
         type: array
@@ -309,7 +265,7 @@ definitions:
         description: A unique identifier for the agent's skill.
         type: string
       inputModes:
-        description: The set of supported input MIME types for this skill, overriding the agent's defaults.
+        description: The set of supported input media types for this skill, overriding the agent's defaults.
         items:
           type: string
         type: array
@@ -317,453 +273,88 @@ definitions:
         description: A human-readable name for the skill.
         type: string
       outputModes:
-        description: The set of supported output MIME types for this skill, overriding the agent's defaults.
+        description: The set of supported output media types for this skill, overriding the agent's defaults.
         items:
           type: string
+        type: array
+      security:
+        description: |-
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           Security schemes necessary for this skill.
+        items:
+          $ref: '#/definitions/Security'
         type: array
       tags:
         description: A set of keywords describing the skill's capabilities.
-        examples:
-          - - cooking
-            - customer support
-            - billing
         items:
           type: string
         type: array
     required:
-      - description
       - id
       - name
+      - description
       - tags
-    type: object
-  Artifact:
-    description: Represents a file, data structure, or other resource generated by an agent during a task.
-    properties:
-      artifactId:
-        description: A unique identifier for the artifact within the scope of the task.
-        type: string
-      description:
-        description: An optional, human-readable description of the artifact.
-        type: string
-      extensions:
-        description: The URIs of extensions that are relevant to this artifact.
-        items:
-          type: string
-        type: array
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions. The key is an extension-specific identifier.
-        type: object
-      name:
-        description: An optional, human-readable name for the artifact.
-        type: string
-      parts:
-        description: An array of content parts that make up the artifact.
-        items:
-          $ref: '#/definitions/Part'
-        type: array
-    required:
-      - artifactId
-      - parts
+    title: Agent Skill
     type: object
   AuthorizationCodeOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Authorization Code flow.
     properties:
       authorizationUrl:
-        description: |-
-          The authorization URL to be used for this flow.
-          This MUST be a URL and use TLS.
+        description: The authorization URL to be used for this flow.
         type: string
       refreshUrl:
-        description: |-
-          The URL to be used for obtaining refresh tokens.
-          This MUST be a URL and use TLS.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
       tokenUrl:
-        description: |-
-          The token URL to be used for this flow.
-          This MUST be a URL and use TLS.
+        description: The token URL to be used for this flow.
         type: string
     required:
       - authorizationUrl
-      - scopes
       - tokenUrl
-    type: object
-  CancelTaskRequest:
-    description: Represents a JSON-RPC request for the `tasks/cancel` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/cancel
-        description: The method name. Must be 'tasks/cancel'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskIdParams'
-        description: The parameters identifying the task to cancel.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  CancelTaskResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/CancelTaskSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/cancel` method.
-  CancelTaskSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/cancel` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/Task'
-        description: The result, containing the final state of the canceled Task object.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - scopes
+    title: Authorization CodeO Auth Flow
     type: object
   ClientCredentialsOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Client Credentials flow.
     properties:
       refreshUrl:
-        description: The URL to be used for obtaining refresh tokens. This MUST be a URL.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
       tokenUrl:
-        description: The token URL to be used for this flow. This MUST be a URL.
+        description: The token URL to be used for this flow.
         type: string
     required:
-      - scopes
       - tokenUrl
-    type: object
-  ContentTypeNotSupportedError:
-    description: |-
-      An A2A-specific error indicating an incompatibility between the requested
-      content types and the agent's capabilities.
-    properties:
-      code:
-        const: -32005
-        description: The error code for an unsupported content type.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Incompatible content types
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  DataPart:
-    description: Represents a structured data segment (e.g., JSON) within a message or artifact.
-    properties:
-      data:
-        additionalProperties: {}
-        description: The structured data content.
-        type: object
-      kind:
-        const: data
-        description: The type of this part, used as a discriminator. Always 'data'.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
-    required:
-      - data
-      - kind
-    type: object
-  DeleteTaskPushNotificationConfigParams:
-    description: Defines parameters for deleting a specific push notification configuration for a task.
-    properties:
-      id:
-        description: The unique identifier of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-      pushNotificationConfigId:
-        description: The ID of the push notification configuration to delete.
-        type: string
-    required:
-      - id
-      - pushNotificationConfigId
-    type: object
-  DeleteTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/delete` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/delete
-        description: The method name. Must be 'tasks/pushNotificationConfig/delete'.
-        type: string
-      params:
-        $ref: '#/definitions/DeleteTaskPushNotificationConfigParams'
-        description: The parameters identifying the push notification configuration to delete.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  DeleteTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/DeleteTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.
-  DeleteTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        description: The result is null on successful deletion.
-        type: 'null'
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  FileBase:
-    description: Defines base properties for a file.
-    properties:
-      mimeType:
-        description: The MIME type of the file (e.g., "application/pdf").
-        type: string
-      name:
-        description: An optional name for the file (e.g., "document.pdf").
-        type: string
-    type: object
-  FilePart:
-    description: |-
-      Represents a file segment within a message or artifact. The file content can be
-      provided either directly as bytes or as a URI.
-    properties:
-      file:
-        anyOf:
-          - $ref: '#/definitions/FileWithBytes'
-          - $ref: '#/definitions/FileWithUri'
-        description: The file content, represented as either a URI or as base64-encoded bytes.
-      kind:
-        const: file
-        description: The type of this part, used as a discriminator. Always 'file'.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
-    required:
-      - file
-      - kind
-    type: object
-  FileWithBytes:
-    description: Represents a file with its content provided directly as a base64-encoded string.
-    properties:
-      bytes:
-        description: The base64-encoded content of the file.
-        type: string
-      mimeType:
-        description: The MIME type of the file (e.g., "application/pdf").
-        type: string
-      name:
-        description: An optional name for the file (e.g., "document.pdf").
-        type: string
-    required:
-      - bytes
-    type: object
-  FileWithUri:
-    description: Represents a file with its content located at a specific URI.
-    properties:
-      mimeType:
-        description: The MIME type of the file (e.g., "application/pdf").
-        type: string
-      name:
-        description: An optional name for the file (e.g., "document.pdf").
-        type: string
-      uri:
-        description: A URL pointing to the file's content.
-        type: string
-    required:
-      - uri
-    type: object
-  GetTaskPushNotificationConfigParams:
-    description: Defines parameters for fetching a specific push notification configuration for a task.
-    properties:
-      id:
-        description: The unique identifier of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-      pushNotificationConfigId:
-        description: The ID of the push notification configuration to retrieve.
-        type: string
-    required:
-      - id
-    type: object
-  GetTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/get` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/get
-        description: The method name. Must be 'tasks/pushNotificationConfig/get'.
-        type: string
-      params:
-        anyOf:
-          - $ref: '#/definitions/TaskIdParams'
-          - $ref: '#/definitions/GetTaskPushNotificationConfigParams'
-        description: The parameters for getting a push notification configuration.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  GetTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/GetTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/get` method.
-  GetTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/get` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/TaskPushNotificationConfig'
-        description: The result, containing the requested push notification configuration.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  GetTaskRequest:
-    description: Represents a JSON-RPC request for the `tasks/get` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/get
-        description: The method name. Must be 'tasks/get'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskQueryParams'
-        description: The parameters for querying a task.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  GetTaskResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/GetTaskSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/get` method.
-  GetTaskSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/get` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/Task'
-        description: The result, containing the requested Task object.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - scopes
+    title: Client CredentialsO Auth Flow
     type: object
   HTTPAuthSecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using HTTP authentication.
     properties:
       bearerFormat:
         description: |-
           A hint to the client to identify how the bearer token is formatted (e.g., "JWT").
-          This is primarily for documentation purposes.
+           This is primarily for documentation purposes.
         type: string
       description:
         description: An optional description for the security scheme.
@@ -771,433 +362,51 @@ definitions:
       scheme:
         description: |-
           The name of the HTTP Authentication scheme to be used in the Authorization header,
-          as defined in RFC7235 (e.g., "Bearer").
-          This value should be registered in the IANA Authentication Scheme registry.
-        type: string
-      type:
-        const: http
-        description: The type of the security scheme. Must be 'http'.
+           as defined in RFC7235 (e.g., "Bearer").
+           This value should be registered in the IANA Authentication Scheme registry.
         type: string
     required:
       - scheme
-      - type
+    title: HTTP Auth Security Scheme
     type: object
   ImplicitOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Implicit flow.
     properties:
       authorizationUrl:
-        description: The authorization URL to be used for this flow. This MUST be a URL.
+        description: The authorization URL to be used for this flow.
         type: string
       refreshUrl:
-        description: The URL to be used for obtaining refresh tokens. This MUST be a URL.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
     required:
       - authorizationUrl
       - scopes
+    title: ImplicitO Auth Flow
     type: object
-  InternalError:
-    description: An error indicating an internal error on the server.
+  MutualTlsSecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Defines a security scheme using mTLS authentication.
     properties:
-      code:
-        const: -32603
-        description: The error code for an internal server error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Internal error
-        description: The error message.
+      description:
+        description: An optional description for the security scheme.
         type: string
     required:
-      - code
-      - message
-    type: object
-  InvalidAgentResponseError:
-    description: |-
-      An A2A-specific error indicating that the agent returned a response that
-      does not conform to the specification for the current method.
-    properties:
-      code:
-        const: -32006
-        description: The error code for an invalid agent response.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Invalid agent response
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  InvalidParamsError:
-    description: An error indicating that the method parameters are invalid.
-    properties:
-      code:
-        const: -32602
-        description: The error code for an invalid parameters error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Invalid parameters
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  InvalidRequestError:
-    description: An error indicating that the JSON sent is not a valid Request object.
-    properties:
-      code:
-        const: -32600
-        description: The error code for an invalid request.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Request payload validation error
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  JSONParseError:
-    description: An error indicating that the server received invalid JSON.
-    properties:
-      code:
-        const: -32700
-        description: The error code for a JSON parse error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Invalid JSON payload
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  JSONRPCError:
-    description: Represents a JSON-RPC 2.0 Error object, included in an error response.
-    properties:
-      code:
-        description: A number that indicates the error type that occurred.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        description: A string providing a short description of the error.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  JSONRPCErrorResponse:
-    description: Represents a JSON-RPC 2.0 Error Response object.
-    properties:
-      error:
-        anyOf:
-          - $ref: '#/definitions/JSONRPCError'
-          - $ref: '#/definitions/JSONParseError'
-          - $ref: '#/definitions/InvalidRequestError'
-          - $ref: '#/definitions/MethodNotFoundError'
-          - $ref: '#/definitions/InvalidParamsError'
-          - $ref: '#/definitions/InternalError'
-          - $ref: '#/definitions/TaskNotFoundError'
-          - $ref: '#/definitions/TaskNotCancelableError'
-          - $ref: '#/definitions/PushNotificationNotSupportedError'
-          - $ref: '#/definitions/UnsupportedOperationError'
-          - $ref: '#/definitions/ContentTypeNotSupportedError'
-          - $ref: '#/definitions/InvalidAgentResponseError'
-        description: An object describing the error that occurred.
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-    required:
-      - error
-      - id
-      - jsonrpc
-    type: object
-  JSONRPCMessage:
-    description: Defines the base structure for any JSON-RPC 2.0 request, response, or notification.
-    properties:
-      id:
-        description: |-
-          A unique identifier established by the client. It must be a String, a Number, or null.
-          The server must reply with the same value in the response. This property is omitted for notifications.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-    required:
-      - jsonrpc
-    type: object
-  JSONRPCRequest:
-    description: Represents a JSON-RPC 2.0 Request object.
-    properties:
-      id:
-        description: |-
-          A unique identifier established by the client. It must be a String, a Number, or null.
-          The server must reply with the same value in the response. This property is omitted for notifications.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        description: A string containing the name of the method to be invoked.
-        type: string
-      params:
-        additionalProperties: {}
-        description: A structured value holding the parameter values to be used during the method invocation.
-        type: object
-    required:
-      - jsonrpc
-      - method
-    type: object
-  JSONRPCResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SendMessageSuccessResponse'
-      - $ref: '#/definitions/SendStreamingMessageSuccessResponse'
-      - $ref: '#/definitions/GetTaskSuccessResponse'
-      - $ref: '#/definitions/CancelTaskSuccessResponse'
-      - $ref: '#/definitions/SetTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/GetTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/ListTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/DeleteTaskPushNotificationConfigSuccessResponse'
-    description: |-
-      A discriminated union representing all possible JSON-RPC 2.0 responses
-      for the A2A specification methods.
-  JSONRPCSuccessResponse:
-    description: Represents a successful JSON-RPC 2.0 Response object.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        description: The value of this member is determined by the method invoked on the Server.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  ListTaskPushNotificationConfigParams:
-    description: Defines parameters for listing all push notification configurations associated with a task.
-    properties:
-      id:
-        description: The unique identifier of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-    required:
-      - id
-    type: object
-  ListTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/list` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/list
-        description: The method name. Must be 'tasks/pushNotificationConfig/list'.
-        type: string
-      params:
-        $ref: '#/definitions/ListTaskPushNotificationConfigParams'
-        description: The parameters identifying the task whose configurations are to be listed.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  ListTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/ListTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/list` method.
-  ListTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/list` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        description: The result, containing an array of all push notification configurations for the task.
-        items:
-          $ref: '#/definitions/TaskPushNotificationConfig'
-        type: array
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  Message:
-    description: Represents a single message in the conversation between a user and an agent.
-    properties:
-      contextId:
-        description: The context identifier for this message, used to group related interactions.
-        type: string
-      extensions:
-        description: The URIs of extensions that are relevant to this message.
-        items:
-          type: string
-        type: array
-      kind:
-        const: message
-        description: The type of this object, used as a discriminator. Always 'message' for a Message.
-        type: string
-      messageId:
-        description: A unique identifier for the message, typically a UUID, generated by the sender.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions. The key is an extension-specific identifier.
-        type: object
-      parts:
-        description: |-
-          An array of content parts that form the message body. A message can be
-          composed of multiple parts of different types (e.g., text and files).
-        items:
-          $ref: '#/definitions/Part'
-        type: array
-      referenceTaskIds:
-        description: A list of other task IDs that this message references for additional context.
-        items:
-          type: string
-        type: array
-      role:
-        description: Identifies the sender of the message. `user` for the client, `agent` for the service.
-        enum:
-          - agent
-          - user
-        type: string
-      taskId:
-        description: The identifier of the task this message is part of. Can be omitted for the first message of a new task.
-        type: string
-    required:
-      - kind
-      - messageId
-      - parts
-      - role
-    type: object
-  MessageSendConfiguration:
-    description: Defines configuration options for a `message/send` or `message/stream` request.
-    properties:
-      acceptedOutputModes:
-        description: A list of output MIME types the client is prepared to accept in the response.
-        items:
-          type: string
-        type: array
-      blocking:
-        description: If true, the client will wait for the task to complete. The server may reject this if the task is long-running.
-        type: boolean
-      historyLength:
-        description: The number of most recent messages from the task's history to retrieve in the response.
-        type: integer
-      pushNotificationConfig:
-        $ref: '#/definitions/PushNotificationConfig'
-        description: Configuration for the agent to send push notifications for updates after the initial response.
-    type: object
-  MessageSendParams:
-    description: |-
-      Defines the parameters for a request to send a message to an agent. This can be used
-      to create a new task, continue an existing one, or restart a task.
-    properties:
-      configuration:
-        $ref: '#/definitions/MessageSendConfiguration'
-        description: Optional configuration for the send request.
-      message:
-        $ref: '#/definitions/Message'
-        description: The message object being sent to the agent.
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions.
-        type: object
-    required:
-      - message
-    type: object
-  MethodNotFoundError:
-    description: An error indicating that the requested method does not exist or is not available.
-    properties:
-      code:
-        const: -32601
-        description: The error code for a method not found error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Method not found
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
+      - description
+    title: Mutual Tls Security Scheme
     type: object
   OAuth2SecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using OAuth 2.0.
     properties:
       description:
@@ -1206,88 +415,224 @@ definitions:
       flows:
         $ref: '#/definitions/OAuthFlows'
         description: An object containing configuration information for the supported OAuth 2.0 flows.
-      type:
-        const: oauth2
-        description: The type of the security scheme. Must be 'oauth2'.
+      oauth2MetadataUrl:
+        description: |-
+          URL to the oauth2 authorization server metadata
+           RFC8414 (https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.
         type: string
     required:
       - flows
-      - type
+    title: O Auth2 Security Scheme
     type: object
   OAuthFlows:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines the configuration for the supported OAuth 2.0 flows.
     properties:
       authorizationCode:
         $ref: '#/definitions/AuthorizationCodeOAuthFlow'
-        description: Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0.
+        description: Configuration for the OAuth Authorization Code flow.
       clientCredentials:
         $ref: '#/definitions/ClientCredentialsOAuthFlow'
-        description: Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0.
+        description: Configuration for the OAuth Client Credentials flow.
       implicit:
         $ref: '#/definitions/ImplicitOAuthFlow'
         description: Configuration for the OAuth Implicit flow.
       password:
         $ref: '#/definitions/PasswordOAuthFlow'
         description: Configuration for the OAuth Resource Owner Password flow.
+    title: O Auth Flows
     type: object
   OpenIdConnectSecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using OpenID Connect.
     properties:
       description:
         description: An optional description for the security scheme.
         type: string
       openIdConnectUrl:
-        description: The OpenID Connect Discovery URL for the OIDC provider's metadata.
-        type: string
-      type:
-        const: openIdConnect
-        description: The type of the security scheme. Must be 'openIdConnect'.
+        description: |-
+          The OpenID Connect Discovery URL for the OIDC provider's metadata.
+           See: https://openid.net/specs/openid-connect-discovery-1_0.html
         type: string
     required:
       - openIdConnectUrl
-      - type
-    type: object
-  Part:
-    anyOf:
-      - $ref: '#/definitions/TextPart'
-      - $ref: '#/definitions/FilePart'
-      - $ref: '#/definitions/DataPart'
-    description: |-
-      A discriminated union representing a part of a message or artifact, which can
-      be text, a file, or structured data.
-  PartBase:
-    description: Defines base properties common to all message or artifact parts.
-    properties:
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
+    title: Open Id Connect Security Scheme
     type: object
   PasswordOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Resource Owner Password flow.
     properties:
       refreshUrl:
-        description: The URL to be used for obtaining refresh tokens. This MUST be a URL.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
       tokenUrl:
-        description: The token URL to be used for this flow. This MUST be a URL.
+        description: The token URL to be used for this flow.
         type: string
     required:
-      - scopes
       - tokenUrl
+      - scopes
+    title: PasswordO Auth Flow
     type: object
-  PushNotificationAuthenticationInfo:
-    description: Defines authentication details for a push notification endpoint.
+  Security:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      schemes:
+        additionalProperties:
+          $ref: '#/definitions/StringList'
+        propertyNames:
+          type: string
+        type: object
+    title: Security
+    type: object
+  SecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Defines a security scheme that can be used to secure an agent's endpoints.
+       This is a discriminated union type based on the OpenAPI 3.2 Security Scheme Object.
+       See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object
+    properties:
+      apiKeySecurityScheme:
+        $ref: '#/definitions/APIKeySecurityScheme'
+        description: API key-based authentication.
+      httpAuthSecurityScheme:
+        $ref: '#/definitions/HTTPAuthSecurityScheme'
+        description: HTTP authentication (Basic, Bearer, etc.).
+      mtlsSecurityScheme:
+        $ref: '#/definitions/MutualTlsSecurityScheme'
+        description: Mutual TLS authentication.
+      oauth2SecurityScheme:
+        $ref: '#/definitions/OAuth2SecurityScheme'
+        description: OAuth 2.0 authentication.
+      openIdConnectSecurityScheme:
+        $ref: '#/definitions/OpenIdConnectSecurityScheme'
+        description: OpenID Connect authentication.
+    title: Security Scheme
+    type: object
+  StringList:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+    properties:
+      list:
+        items:
+          type: string
+        type: array
+    title: String List
+    type: object
+  Artifact:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Artifacts represent task outputs.
+    properties:
+      artifactId:
+        description: |-
+          Unique identifier (e.g. UUID) for the artifact. It must be at least unique
+           within a task.
+        type: string
+      description:
+        description: A human readable description of the artifact, optional.
+        type: string
+      extensions:
+        description: The URIs of extensions that are present or contributed to this Artifact.
+        items:
+          type: string
+        type: array
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: Optional metadata included with the artifact.
+      name:
+        description: A human readable name for the artifact.
+        type: string
+      parts:
+        description: The content of the artifact. Must contain at least one part.
+        items:
+          $ref: '#/definitions/Part'
+        type: array
+    required:
+      - artifactId
+      - parts
+    title: Artifact
+    type: object
+  DataPart:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: DataPart represents a structured blob.
+    properties:
+      data:
+        $ref: '#/definitions/Struct'
+        description: A JSON object containing arbitrary data.
+    title: Data Part
+    type: object
+    required:
+      - data
+  FilePart:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      FilePart represents the different ways files can be provided. If files are
+       small, directly feeding the bytes is supported via file_with_bytes. If the
+       file is large, the agent should read the content as appropriate directly
+       from the file_with_uri source.
+    properties:
+      fileWithBytes:
+        description: The base64-encoded content of the file.
+        pattern: ^[A-Za-z0-9+/]*={0,2}$
+        type: string
+      fileWithUri:
+        description: A URL pointing to the file's content.
+        type: string
+      mediaType:
+        description: The media type of the file (e.g., "application/pdf").
+        type: string
+      name:
+        description: An optional name for the file (e.g., "document.pdf").
+        type: string
+    required:
+      - mediaType
+      - name
+    title: File Part
+    type: object
+  Part:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Part represents a container for a section of communication content.
+       Parts can be purely textual, some sort of file (image, video, etc) or
+       a structured data blob (i.e. JSON).
+    properties:
+      data:
+        $ref: '#/definitions/DataPart'
+        description: The structured data content.
+      file:
+        $ref: '#/definitions/FilePart'
+        description: The file content, represented as either a URI or as base64-encoded bytes.
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: Optional metadata associated with this part.
+      text:
+        description: The string content of the text part.
+        type: string
+    title: Part
+    type: object
+  AuthenticationInfo:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Defines authentication details, used for push notifications.
     properties:
       credentials:
-        description: Optional credentials required by the push notification endpoint.
+        description: Optional credentials
         type: string
       schemes:
         description: A list of supported authentication schemes (e.g., 'Basic', 'Bearer').
@@ -1296,501 +641,594 @@ definitions:
         type: array
     required:
       - schemes
+    title: Authentication Info
+    type: object
+  CancelTaskRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/cancel` method.
+    properties:
+      name:
+        description: |-
+          The resource name of the task to cancel.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - name
+    title: Cancel Task Request
+    type: object
+  DeleteTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/pushNotificationConfig/delete` method.
+    properties:
+      name:
+        description: |-
+          The resource name of the config to delete.
+           Format: tasks/{task_id}/pushNotificationConfigs/{config_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - name
+    title: Delete Task Push Notification Config Request
+    type: object
+  GetExtendedAgentCardRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+    title: Get Extended Agent Card Request
+    type: object
+  GetTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      name:
+        description: |-
+          The resource name of the config to retrieve.
+           Format: tasks/{task_id}/pushNotificationConfigs/{config_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - name
+    title: Get Task Push Notification Config Request
+    type: object
+  GetTaskRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/get` method.
+    properties:
+      historyLength:
+        description: The maximum number of messages to include in the history.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      name:
+        description: |-
+          The resource name of the task.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - name
+    title: Get Task Request
+    type: object
+  ListTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      pageSize:
+        description: The maximum number of configurations to return.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      pageToken:
+        description: A page token received from a previous ListTaskPushNotificationConfigRequest call.
+        type: string
+      parent:
+        description: |-
+          The parent task resource.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - parent
+      - pageSize
+      - pageToken
+    title: List Task Push Notification Config Request
+    type: object
+  ListTaskPushNotificationConfigResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Represents a successful response for the `tasks/pushNotificationConfig/list`
+       method.
+    properties:
+      configs:
+        description: The list of push notification configurations.
+        items:
+          $ref: '#/definitions/TaskPushNotificationConfig'
+        type: array
+      nextPageToken:
+        description: |-
+          A token, which can be sent as `page_token` to retrieve the next page.
+           If this field is omitted, there are no subsequent pages.
+        type: string
+    required:
+      - nextPageToken
+    title: List Task Push Notification Config Response
     type: object
   PushNotificationConfig:
-    description: Defines the configuration for setting up push notifications for task updates.
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Configuration for setting up push notifications for task updates.
     properties:
       authentication:
-        $ref: '#/definitions/PushNotificationAuthenticationInfo'
-        description: Optional authentication details for the agent to use when calling the notification URL.
+        $ref: '#/definitions/AuthenticationInfo'
+        description: Information about the authentication to sent with the notification
       id:
-        description: |-
-          A unique ID for the push notification configuration, created by the server
-          to support multiple notification callbacks.
+        description: A unique identifier (e.g. UUID) for this push notification.
         type: string
       token:
-        description: A unique token for this task or session to validate incoming push notifications.
+        description: Token unique for this task/session
         type: string
       url:
-        description: The callback URL where the agent should send push notifications.
+        description: Url to send the notification too
         type: string
     required:
       - url
+    title: Push Notification Config
     type: object
-  PushNotificationNotSupportedError:
-    description: An A2A-specific error indicating that the agent does not support push notifications.
+  TaskPushNotificationConfig:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      A container associating a push notification configuration with a specific
+       task.
     properties:
-      code:
-        const: -32003
-        description: The error code for when push notifications are not supported.
-        type: integer
-      data:
+      name:
         description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Push Notification is not supported
-        description: The error message.
+          The resource name of the config.
+           Format: tasks/{task_id}/pushNotificationConfigs/{config_id}
+        type: string
+      pushNotificationConfig:
+        $ref: '#/definitions/PushNotificationConfig'
+        description: The push notification configuration details.
+    required:
+      - name
+      - pushNotificationConfig
+    title: Task Push Notification Config
+    type: object
+  ListTasksRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Parameters for listing tasks with optional filtering criteria.
+    properties:
+      contextId:
+        description: Filter tasks by context ID to get tasks from a specific conversation or session.
+        type: string
+      historyLength:
+        description: The maximum number of messages to include in each task's history.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      includeArtifacts:
+        description: |-
+          Whether to include artifacts in the returned tasks.
+           Defaults to false to reduce payload size.
+        type: boolean
+      lastUpdatedAfter:
+        description: |-
+          Filter tasks updated after this timestamp (milliseconds since epoch).
+           Only tasks with a last updated time greater than or equal to this value will be returned.
+        type: integer
+      pageSize:
+        description: |-
+          Maximum number of tasks to return. Must be between 1 and 100.
+           Defaults to 50 if not specified.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      pageToken:
+        description: Token for pagination. Use the next_page_token from a previous ListTasksResponse.
+        type: string
+      status:
+        description: Filter tasks by their current status state.
+        enum:
+          - TASK_STATE_UNSPECIFIED
+          - TASK_STATE_SUBMITTED
+          - TASK_STATE_WORKING
+          - TASK_STATE_COMPLETED
+          - TASK_STATE_FAILED
+          - TASK_STATE_CANCELLED
+          - TASK_STATE_INPUT_REQUIRED
+          - TASK_STATE_REJECTED
+          - TASK_STATE_AUTH_REQUIRED
+        title: Task State
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
         type: string
     required:
-      - code
-      - message
+      - tenant
+      - contextId
+      - status
+      - pageToken
+      - lastUpdatedAfter
+    title: List Tasks Request
     type: object
-  SecurityScheme:
-    anyOf:
-      - $ref: '#/definitions/APIKeySecurityScheme'
-      - $ref: '#/definitions/HTTPAuthSecurityScheme'
-      - $ref: '#/definitions/OAuth2SecurityScheme'
-      - $ref: '#/definitions/OpenIdConnectSecurityScheme'
+  ListTasksResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Result object for tasks/list method containing an array of tasks and pagination information.
+    properties:
+      nextPageToken:
+        description: Token for retrieving the next page. Empty string if no more results.
+        type: string
+      pageSize:
+        description: The size of page requested.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      tasks:
+        description: Array of tasks matching the specified criteria.
+        items:
+          $ref: '#/definitions/Task'
+        type: array
+      totalSize:
+        description: Total number of tasks available (before pagination).
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+    required:
+      - tasks
+      - nextPageToken
+      - pageSize
+      - totalSize
+    title: List Tasks Response
+    type: object
+  Message:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      Defines a security scheme that can be used to secure an agent's endpoints.
-      This is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object.
-  SecuritySchemeBase:
-    description: Defines base properties shared by all security scheme objects.
+      Message is one unit of communication between client and server. It is
+       associated with a context and optionally a task. Since the server is
+       responsible for the context definition, it must always provide a context_id
+       in its messages. The client can optionally provide the context_id if it
+       knows the context to associate the message to. Similarly for task_id,
+       except the server decides if a task is created and whether to include the
+       task_id.
     properties:
-      description:
-        description: An optional description for the security scheme.
+      contextId:
+        description: |-
+          The context id of the message. This is optional and if set, the message
+           will be associated with the given context.
         type: string
-    type: object
-  SendMessageRequest:
-    description: Represents a JSON-RPC request for the `message/send` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
+      extensions:
+        description: The URIs of extensions that are present or contributed to this Message.
+        items:
+          type: string
+        type: array
+      messageId:
+        description: |-
+          The unique identifier (e.g. UUID) of the message. This is required and
+           created by the message creator.
         type: string
-      method:
-        const: message/send
-        description: The method name. Must be 'message/send'.
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: |-
+          protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+           Any optional metadata to provide along with the message.
+      parts:
+        description: |-
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           Parts is the container of the message content.
+        items:
+          $ref: '#/definitions/Part'
+        type: array
+      referenceTaskIds:
+        description: A list of task IDs that this message references for additional context.
+        items:
+          type: string
+        type: array
+      role:
+        description: Identifies the sender of the message.
+        enum:
+          - ROLE_UNSPECIFIED
+          - ROLE_USER
+          - ROLE_AGENT
+        title: Role
         type: string
-      params:
-        $ref: '#/definitions/MessageSendParams'
-        description: The parameters for sending a message.
+      taskId:
+        description: |-
+          The task id of the message. This is optional and if set, the message
+           will be associated with the given task.
+        type: string
     required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  SendMessageResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SendMessageSuccessResponse'
-    description: Represents a JSON-RPC response for the `message/send` method.
-  SendMessageSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `message/send` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        anyOf:
-          - $ref: '#/definitions/Task'
-          - $ref: '#/definitions/Message'
-        description: The result, which can be a direct reply Message or the initial Task object.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  SendStreamingMessageRequest:
-    description: Represents a JSON-RPC request for the `message/stream` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: message/stream
-        description: The method name. Must be 'message/stream'.
-        type: string
-      params:
-        $ref: '#/definitions/MessageSendParams'
-        description: The parameters for sending a message.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  SendStreamingMessageResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SendStreamingMessageSuccessResponse'
-    description: Represents a JSON-RPC response for the `message/stream` method.
-  SendStreamingMessageSuccessResponse:
-    description: |-
-      Represents a successful JSON-RPC response for the `message/stream` method.
-      The server may send multiple response objects for a single request.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        anyOf:
-          - $ref: '#/definitions/Task'
-          - $ref: '#/definitions/Message'
-          - $ref: '#/definitions/TaskStatusUpdateEvent'
-          - $ref: '#/definitions/TaskArtifactUpdateEvent'
-        description: The result, which can be a Message, Task, or a streaming update event.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  SetTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/set` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/set
-        description: The method name. Must be 'tasks/pushNotificationConfig/set'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskPushNotificationConfig'
-        description: The parameters for setting the push notification configuration.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  SetTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SetTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/set` method.
-  SetTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/set` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/TaskPushNotificationConfig'
-        description: The result, containing the configured push notification settings.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - messageId
+      - role
+      - parts
+    title: Message
     type: object
   Task:
-    description: Represents a single, stateful operation or conversation between a client and an agent.
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Task is the core unit of action for A2A. It has a current status
+       and when results are created for the task they are stored in the
+       artifact. If there are multiple turns for a task, these are stored in
+       history.
     properties:
       artifacts:
-        description: A collection of artifacts generated by the agent during the execution of the task.
+        description: A set of output artifacts for a Task.
         items:
           $ref: '#/definitions/Artifact'
         type: array
       contextId:
-        description: A server-generated identifier for maintaining context across multiple related tasks or interactions.
+        description: |-
+          Unique identifier (e.g. UUID) for the contextual collection of interactions
+           (tasks and messages). Created by the A2A server.
         type: string
       history:
-        description: An array of messages exchanged during the task, representing the conversation history.
+        description: |-
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           The history of interactions from a task.
         items:
           $ref: '#/definitions/Message'
         type: array
       id:
-        description: A unique identifier for the task, generated by the client for a new task or provided by the agent.
-        type: string
-      kind:
-        const: task
-        description: The type of this object, used as a discriminator. Always 'task' for a Task.
+        description: |-
+          Unique identifier (e.g. UUID) for the task, generated by the server for a
+           new task.
         type: string
       metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions. The key is an extension-specific identifier.
-        type: object
+        $ref: '#/definitions/Struct'
+        description: |-
+          protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+           A key/value object to store custom metadata about a task.
       status:
         $ref: '#/definitions/TaskStatus'
-        description: The current status of the task, including its state and a descriptive message.
+        description: The current status of a Task, including state and a message.
     required:
-      - contextId
       - id
-      - kind
+      - contextId
       - status
+    title: Task
+    type: object
+  TaskStatus:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: A container for the status of a task
+    properties:
+      message:
+        $ref: '#/definitions/Message'
+        description: A message associated with the status.
+      state:
+        description: The current state of this task.
+        enum:
+          - TASK_STATE_UNSPECIFIED
+          - TASK_STATE_SUBMITTED
+          - TASK_STATE_WORKING
+          - TASK_STATE_COMPLETED
+          - TASK_STATE_FAILED
+          - TASK_STATE_CANCELLED
+          - TASK_STATE_INPUT_REQUIRED
+          - TASK_STATE_REJECTED
+          - TASK_STATE_AUTH_REQUIRED
+        title: Task State
+        type: string
+      timestamp:
+        $ref: '#/definitions/Timestamp'
+        description: |-
+          ISO 8601 Timestamp when the status was recorded.
+           Example: "2023-10-27T10:00:00Z"
+    required:
+      - state
+    title: Task Status
+    type: object
+  Timestamp:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    format: date-time
+    title: Timestamp
+    type: string
+  SendMessageConfiguration:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Configuration of a send message request.
+    properties:
+      acceptedOutputModes:
+        description: A list of media types the client is prepared to accept for response parts. Agents SHOULD use this to tailor their output.
+        items:
+          type: string
+        type: array
+      blocking:
+        description: If true, the operation waits until the task reaches a terminal state before returning. Default is false.
+        type: boolean
+      historyLength:
+        description: The maximum number of messages to include in the history.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      pushNotificationConfig:
+        $ref: '#/definitions/PushNotificationConfig'
+        description: Configuration for the agent to send push notifications for task updates.
+    required:
+      - blocking
+    title: Send Message Configuration
+    type: object
+  SendMessageRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      /////////// Request Messages ///////////
+       Represents a request for the `message/send` method.
+    properties:
+      configuration:
+        $ref: '#/definitions/SendMessageConfiguration'
+        description: Configuration for the send request.
+      message:
+        $ref: '#/definitions/Message'
+        description: The message to send to the agent.
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: A flexible key-value map for passing additional context or parameters.
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+    title: Send Message Request
+    type: object
+  SendMessageResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: ////// Response Messages ///////////
+    properties:
+      message:
+        $ref: '#/definitions/Message'
+      task:
+        $ref: '#/definitions/Task'
+    title: Send Message Response
+    type: object
+  SetTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/pushNotificationConfig/set` method.
+    properties:
+      config:
+        $ref: '#/definitions/TaskPushNotificationConfig'
+        description: The configuration to create.
+      configId:
+        description: The ID for the new config.
+        type: string
+      parent:
+        description: |-
+          The parent task resource for this config.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - parent
+      - configId
+      - config
+    title: Set Task Push Notification Config Request
+    type: object
+  StreamResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: A wrapper object used in streaming operations to encapsulate different types of response data.
+    properties:
+      artifactUpdate:
+        $ref: '#/definitions/TaskArtifactUpdateEvent'
+        description: An event indicating a task artifact update.
+      message:
+        $ref: '#/definitions/Message'
+        description: A Message object containing a message from the agent.
+      statusUpdate:
+        $ref: '#/definitions/TaskStatusUpdateEvent'
+        description: An event indicating a task status update.
+      task:
+        $ref: '#/definitions/Task'
+        description: A Task object containing the current state of the task.
+    title: Stream Response
     type: object
   TaskArtifactUpdateEvent:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      An event sent by the agent to notify the client that an artifact has been
-      generated or updated. This is typically used in streaming models.
+      TaskArtifactUpdateEvent represents a task delta where an artifact has
+       been generated.
     properties:
       append:
-        description: If true, the content of this artifact should be appended to a previously sent artifact with the same ID.
+        description: |-
+          If true, the content of this artifact should be appended to a previously
+           sent artifact with the same ID.
         type: boolean
       artifact:
         $ref: '#/definitions/Artifact'
         description: The artifact that was generated or updated.
       contextId:
-        description: The context ID associated with the task.
-        type: string
-      kind:
-        const: artifact-update
-        description: The type of this event, used as a discriminator. Always 'artifact-update'.
+        description: The id of the context that this task belongs to.
         type: string
       lastChunk:
         description: If true, this is the final chunk of the artifact.
         type: boolean
       metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions.
-        type: object
+        $ref: '#/definitions/Struct'
+        description: Optional metadata associated with the artifact update.
       taskId:
-        description: The ID of the task this artifact belongs to.
+        description: The id of the task for this artifact.
         type: string
     required:
-      - artifact
+      - taskId
       - contextId
-      - kind
-      - taskId
-    type: object
-  TaskIdParams:
-    description: Defines parameters containing a task ID, used for simple task operations.
-    properties:
-      id:
-        description: The unique identifier of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-    required:
-      - id
-    type: object
-  TaskNotCancelableError:
-    description: An A2A-specific error indicating that the task is in a state where it cannot be canceled.
-    properties:
-      code:
-        const: -32002
-        description: The error code for a task that cannot be canceled.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Task cannot be canceled
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  TaskNotFoundError:
-    description: An A2A-specific error indicating that the requested task ID was not found.
-    properties:
-      code:
-        const: -32001
-        description: The error code for a task not found error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Task not found
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  TaskPushNotificationConfig:
-    description: A container associating a push notification configuration with a specific task.
-    properties:
-      pushNotificationConfig:
-        $ref: '#/definitions/PushNotificationConfig'
-        description: The push notification configuration for this task.
-      taskId:
-        description: The ID of the task.
-        type: string
-    required:
-      - pushNotificationConfig
-      - taskId
-    type: object
-  TaskQueryParams:
-    description: Defines parameters for querying a task, with an option to limit history length.
-    properties:
-      historyLength:
-        description: The number of most recent messages from the task's history to retrieve.
-        type: integer
-      id:
-        description: The unique identifier of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-    required:
-      - id
-    type: object
-  TaskResubscriptionRequest:
-    description: Represents a JSON-RPC request for the `tasks/resubscribe` method, used to resume a streaming connection.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/resubscribe
-        description: The method name. Must be 'tasks/resubscribe'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskIdParams'
-        description: The parameters identifying the task to resubscribe to.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  TaskState:
-    description: Defines the lifecycle states of a Task.
-    enum:
-      - submitted
-      - working
-      - input-required
-      - completed
-      - canceled
-      - failed
-      - rejected
-      - auth-required
-      - unknown
-    type: string
-  TaskStatus:
-    description: Represents the status of a task at a specific point in time.
-    properties:
-      message:
-        $ref: '#/definitions/Message'
-        description: An optional, human-readable message providing more details about the current status.
-      state:
-        $ref: '#/definitions/TaskState'
-        description: The current state of the task's lifecycle.
-      timestamp:
-        description: An ISO 8601 datetime string indicating when this status was recorded.
-        examples:
-          - '2023-10-27T10:00:00Z'
-        type: string
-    required:
-      - state
+      - artifact
+    title: Task Artifact Update Event
     type: object
   TaskStatusUpdateEvent:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      An event sent by the agent to notify the client of a change in a task's status.
-      This is typically used in streaming or subscription models.
+      An event sent by the agent to notify the client of a change in a task's
+       status.
     properties:
       contextId:
-        description: The context ID associated with the task.
+        description: The id of the context that the task belongs to
         type: string
       final:
         description: If true, this is the final event in the stream for this interaction.
         type: boolean
-      kind:
-        const: status-update
-        description: The type of this event, used as a discriminator. Always 'status-update'.
-        type: string
       metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions.
-        type: object
+        $ref: '#/definitions/Struct'
+        description: Optional metadata to associate with the task update.
       status:
         $ref: '#/definitions/TaskStatus'
         description: The new status of the task.
       taskId:
-        description: The ID of the task that was updated.
+        description: The id of the task that is changed
         type: string
     required:
-      - contextId
-      - final
-      - kind
-      - status
       - taskId
+      - contextId
+      - status
+      - final
+    title: Task Status Update Event
     type: object
-  TextPart:
-    description: Represents a text segment within a message or artifact.
+  SubscribeToTaskRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     properties:
-      kind:
-        const: text
-        description: The type of this part, used as a discriminator. Always 'text'.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
-      text:
-        description: The string content of the text part.
-        type: string
-    required:
-      - kind
-      - text
-    type: object
-  TransportProtocol:
-    description: Supported A2A transport protocols.
-    enum:
-      - JSONRPC
-      - GRPC
-      - HTTP+JSON
-    type: string
-  UnsupportedOperationError:
-    description: An A2A-specific error indicating that the requested operation is not supported by the agent.
-    properties:
-      code:
-        const: -32004
-        description: The error code for an unsupported operation.
-        type: integer
-      data:
+      name:
         description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: This operation is not supported
-        description: The error message.
+          The resource name of the task to subscribe to.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
         type: string
     required:
-      - code
-      - message
+      - tenant
+      - name
+    title: Subscribe To Task Request
     type: object

--- a/src/a2a_types.rs
+++ b/src/a2a_types.rs
@@ -35,255 +35,13 @@ pub mod error {
         }
     }
 }
-#[doc = "A discriminated union of all standard JSON-RPC and A2A-specific error types."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"A discriminated union of all standard JSON-RPC and A2A-specific error types.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONParseError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InvalidRequestError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/MethodNotFoundError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InvalidParamsError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InternalError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskNotFoundError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskNotCancelableError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/PushNotificationNotSupportedError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/UnsupportedOperationError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/ContentTypeNotSupportedError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InvalidAgentResponseError\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct A2aError {
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_0: ::std::option::Option<JsonParseError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_1: ::std::option::Option<InvalidRequestError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_2: ::std::option::Option<MethodNotFoundError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_3: ::std::option::Option<InvalidParamsError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_4: ::std::option::Option<InternalError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_5: ::std::option::Option<TaskNotFoundError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_6: ::std::option::Option<TaskNotCancelableError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_7: ::std::option::Option<PushNotificationNotSupportedError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_8: ::std::option::Option<UnsupportedOperationError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_9: ::std::option::Option<ContentTypeNotSupportedError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_10: ::std::option::Option<InvalidAgentResponseError>,
-}
-impl ::std::convert::From<&A2aError> for A2aError {
-    fn from(value: &A2aError) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for A2aError {
-    fn default() -> Self {
-        Self {
-            subtype_0: Default::default(),
-            subtype_1: Default::default(),
-            subtype_2: Default::default(),
-            subtype_3: Default::default(),
-            subtype_4: Default::default(),
-            subtype_5: Default::default(),
-            subtype_6: Default::default(),
-            subtype_7: Default::default(),
-            subtype_8: Default::default(),
-            subtype_9: Default::default(),
-            subtype_10: Default::default(),
-        }
-    }
-}
-impl A2aError {
-    pub fn builder() -> builder::A2aError {
-        Default::default()
-    }
-}
-#[doc = "A discriminated union representing all possible JSON-RPC 2.0 requests supported by the A2A specification."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"A discriminated union representing all possible JSON-RPC 2.0 requests supported by the A2A specification.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SendMessageRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SendStreamingMessageRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/CancelTaskRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SetTaskPushNotificationConfigRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskPushNotificationConfigRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskResubscriptionRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/ListTaskPushNotificationConfigRequest\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/DeleteTaskPushNotificationConfigRequest\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum A2aRequest {
-    SendMessageRequest(SendMessageRequest),
-    SendStreamingMessageRequest(SendStreamingMessageRequest),
-    GetTaskRequest(GetTaskRequest),
-    CancelTaskRequest(CancelTaskRequest),
-    SetTaskPushNotificationConfigRequest(SetTaskPushNotificationConfigRequest),
-    GetTaskPushNotificationConfigRequest(GetTaskPushNotificationConfigRequest),
-    TaskResubscriptionRequest(TaskResubscriptionRequest),
-    ListTaskPushNotificationConfigRequest(ListTaskPushNotificationConfigRequest),
-    DeleteTaskPushNotificationConfigRequest(DeleteTaskPushNotificationConfigRequest),
-}
-impl ::std::convert::From<&Self> for A2aRequest {
-    fn from(value: &A2aRequest) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<SendMessageRequest> for A2aRequest {
-    fn from(value: SendMessageRequest) -> Self {
-        Self::SendMessageRequest(value)
-    }
-}
-impl ::std::convert::From<SendStreamingMessageRequest> for A2aRequest {
-    fn from(value: SendStreamingMessageRequest) -> Self {
-        Self::SendStreamingMessageRequest(value)
-    }
-}
-impl ::std::convert::From<GetTaskRequest> for A2aRequest {
-    fn from(value: GetTaskRequest) -> Self {
-        Self::GetTaskRequest(value)
-    }
-}
-impl ::std::convert::From<CancelTaskRequest> for A2aRequest {
-    fn from(value: CancelTaskRequest) -> Self {
-        Self::CancelTaskRequest(value)
-    }
-}
-impl ::std::convert::From<SetTaskPushNotificationConfigRequest> for A2aRequest {
-    fn from(value: SetTaskPushNotificationConfigRequest) -> Self {
-        Self::SetTaskPushNotificationConfigRequest(value)
-    }
-}
-impl ::std::convert::From<GetTaskPushNotificationConfigRequest> for A2aRequest {
-    fn from(value: GetTaskPushNotificationConfigRequest) -> Self {
-        Self::GetTaskPushNotificationConfigRequest(value)
-    }
-}
-impl ::std::convert::From<TaskResubscriptionRequest> for A2aRequest {
-    fn from(value: TaskResubscriptionRequest) -> Self {
-        Self::TaskResubscriptionRequest(value)
-    }
-}
-impl ::std::convert::From<ListTaskPushNotificationConfigRequest> for A2aRequest {
-    fn from(value: ListTaskPushNotificationConfigRequest) -> Self {
-        Self::ListTaskPushNotificationConfigRequest(value)
-    }
-}
-impl ::std::convert::From<DeleteTaskPushNotificationConfigRequest> for A2aRequest {
-    fn from(value: DeleteTaskPushNotificationConfigRequest) -> Self {
-        Self::DeleteTaskPushNotificationConfigRequest(value)
-    }
-}
 #[doc = "Defines optional capabilities supported by an agent."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Agent Capabilities\","]
 #[doc = "  \"description\": \"Defines optional capabilities supported by an agent.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"properties\": {"]
@@ -303,14 +61,17 @@ impl ::std::convert::From<DeleteTaskPushNotificationConfigRequest> for A2aReques
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    },"]
 #[doc = "    \"streaming\": {"]
-#[doc = "      \"description\": \"Indicates if the agent supports Server-Sent Events (SSE) for streaming responses.\","]
+#[doc = "      \"description\": \"Indicates if the agent supports streaming responses.\","]
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentCapabilities {
     #[doc = "A list of protocol extensions supported by the agent."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
@@ -329,14 +90,9 @@ pub struct AgentCapabilities {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub state_transition_history: ::std::option::Option<bool>,
-    #[doc = "Indicates if the agent supports Server-Sent Events (SSE) for streaming responses."]
+    #[doc = "Indicates if the agent supports streaming responses."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub streaming: ::std::option::Option<bool>,
-}
-impl ::std::convert::From<&AgentCapabilities> for AgentCapabilities {
-    fn from(value: &AgentCapabilities) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for AgentCapabilities {
     fn default() -> Self {
@@ -353,13 +109,14 @@ impl AgentCapabilities {
         Default::default()
     }
 }
-#[doc = "The AgentCard is a self-describing manifest for an agent. It provides essential\nmetadata including the agent's identity, capabilities, skills, supported\ncommunication methods, and security requirements."]
+#[doc = "AgentCard is a self-describing manifest for an agent. It provides essential\n metadata including the agent's identity, capabilities, skills, supported\n communication methods, and security requirements.\n Next ID: 20"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The AgentCard is a self-describing manifest for an agent. It provides essential\\nmetadata including the agent's identity, capabilities, skills, supported\\ncommunication methods, and security requirements.\","]
+#[doc = "  \"title\": \"Agent Card\","]
+#[doc = "  \"description\": \"AgentCard is a self-describing manifest for an agent. It provides essential\\n metadata including the agent's identity, capabilities, skills, supported\\n communication methods, and security requirements.\\n Next ID: 20\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"capabilities\","]
@@ -369,44 +126,40 @@ impl AgentCapabilities {
 #[doc = "    \"name\","]
 #[doc = "    \"protocolVersion\","]
 #[doc = "    \"skills\","]
-#[doc = "    \"url\","]
 #[doc = "    \"version\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"additionalInterfaces\": {"]
-#[doc = "      \"description\": \"A list of additional supported interfaces (transport and URL combinations).\\nThis allows agents to expose multiple transports, potentially at different URLs.\\n\\nBest practices:\\n- SHOULD include all supported transports for completeness\\n- SHOULD include an entry matching the main 'url' and 'preferredTransport'\\n- MAY reuse URLs if multiple transports are available at the same endpoint\\n- MUST accurately declare the transport available at each URL\\n\\nClients can select any interface from this list based on their transport capabilities\\nand preferences. This enables transport negotiation and fallback scenarios.\","]
+#[doc = "      \"description\": \"DEPRECATED: Use 'supported_interfaces' instead.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/AgentInterface\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"capabilities\": {"]
-#[doc = "      \"description\": \"A declaration of optional capabilities supported by the agent.\","]
+#[doc = "      \"description\": \"A2A Capability set supported by the agent.\","]
 #[doc = "      \"$ref\": \"#/definitions/AgentCapabilities\""]
 #[doc = "    },"]
 #[doc = "    \"defaultInputModes\": {"]
-#[doc = "      \"description\": \"Default set of supported input MIME types for all skills, which can be\\noverridden on a per-skill basis.\","]
+#[doc = "      \"description\": \"protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\\n The set of interaction modes that the agent supports across all skills.\\n This can be overridden per skill. Defined as media types.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"defaultOutputModes\": {"]
-#[doc = "      \"description\": \"Default set of supported output MIME types for all skills, which can be\\noverridden on a per-skill basis.\","]
+#[doc = "      \"description\": \"The media types supported as outputs from this agent.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"description\": {"]
-#[doc = "      \"description\": \"A human-readable description of the agent, assisting users and other agents\\nin understanding its purpose.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"Agent that helps users with recipes and cooking.\""]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"A human-readable description of the agent, assisting users and other agents\\n in understanding its purpose.\\n Example: \\\"Agent that helps users with recipes and cooking.\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"documentationUrl\": {"]
-#[doc = "      \"description\": \"An optional URL to the agent's documentation.\","]
+#[doc = "      \"description\": \"A url to provide additional documentation about the agent.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"iconUrl\": {"]
@@ -414,49 +167,36 @@ impl AgentCapabilities {
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"name\": {"]
-#[doc = "      \"description\": \"A human-readable name for the agent.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"Recipe Agent\""]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"A human readable name for the agent.\\n Example: \\\"Recipe Agent\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"preferredTransport\": {"]
-#[doc = "      \"description\": \"The transport protocol for the preferred endpoint (the main 'url' field).\\nIf not specified, defaults to 'JSONRPC'.\\n\\nIMPORTANT: The transport specified here MUST be available at the main 'url'.\\nThis creates a binding between the main URL and its supported transport protocol.\\nClients should prefer this transport and URL combination when both are supported.\","]
-#[doc = "      \"default\": \"JSONRPC\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"JSONRPC\","]
-#[doc = "        \"GRPC\","]
-#[doc = "        \"HTTP+JSON\""]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"DEPRECATED: Use 'supported_interfaces' instead.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"protocolVersion\": {"]
-#[doc = "      \"description\": \"The version of the A2A protocol this agent supports.\","]
-#[doc = "      \"default\": \"0.2.6\","]
+#[doc = "      \"description\": \"The version of the A2A protocol this agent supports.\\n Default: \\\"1.0\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"provider\": {"]
-#[doc = "      \"description\": \"Information about the agent's service provider.\","]
+#[doc = "      \"description\": \"The service provider of the agent.\","]
 #[doc = "      \"$ref\": \"#/definitions/AgentProvider\""]
 #[doc = "    },"]
 #[doc = "    \"security\": {"]
-#[doc = "      \"description\": \"A list of security requirement objects that apply to all agent interactions. Each object\\nlists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.\","]
+#[doc = "      \"description\": \"protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\\n Security requirements for contacting the agent.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
-#[doc = "        \"type\": \"object\","]
-#[doc = "        \"additionalProperties\": {"]
-#[doc = "          \"type\": \"array\","]
-#[doc = "          \"items\": {"]
-#[doc = "            \"type\": \"string\""]
-#[doc = "          }"]
-#[doc = "        }"]
+#[doc = "        \"$ref\": \"#/definitions/Security\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"securitySchemes\": {"]
-#[doc = "      \"description\": \"A declaration of the security schemes available to authorize requests. The key is the\\nscheme name. Follows the OpenAPI 3.0 Security Scheme Object.\","]
+#[doc = "      \"description\": \"The security scheme details used for authenticating with this agent.\","]
 #[doc = "      \"type\": \"object\","]
 #[doc = "      \"additionalProperties\": {"]
 #[doc = "        \"$ref\": \"#/definitions/SecurityScheme\""]
+#[doc = "      },"]
+#[doc = "      \"propertyNames\": {"]
+#[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"signatures\": {"]
@@ -467,54 +207,58 @@ impl AgentCapabilities {
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"skills\": {"]
-#[doc = "      \"description\": \"The set of skills, or distinct capabilities, that the agent can perform.\","]
+#[doc = "      \"description\": \"Skills represent an ability of an agent. It is largely\\n a descriptive concept but represents a more focused set of behaviors that the\\n agent is likely to succeed at.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/AgentSkill\""]
 #[doc = "      }"]
 #[doc = "    },"]
-#[doc = "    \"supportsAuthenticatedExtendedCard\": {"]
-#[doc = "      \"description\": \"If true, the agent can provide an extended agent card with additional details\\nto authenticated users. Defaults to false.\","]
+#[doc = "    \"supportedInterfaces\": {"]
+#[doc = "      \"description\": \"Ordered list of supported interfaces. First entry is preferred.\","]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/definitions/AgentInterface\""]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"supportsExtendedAgentCard\": {"]
+#[doc = "      \"description\": \"Whether the agent supports providing an extended agent card when authenticated.\","]
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    },"]
 #[doc = "    \"url\": {"]
-#[doc = "      \"description\": \"The preferred endpoint URL for interacting with the agent.\\nThis URL MUST support the transport specified by 'preferredTransport'.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"https://api.example.com/a2a/v1\""]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"DEPRECATED: Use 'supported_interfaces' instead.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"version\": {"]
-#[doc = "      \"description\": \"The agent's own version number. The format is defined by the provider.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"1.0.0\""]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"The version of the agent.\\n Example: \\\"1.0.0\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentCard {
-    #[doc = "A list of additional supported interfaces (transport and URL combinations).\nThis allows agents to expose multiple transports, potentially at different URLs.\n\nBest practices:\n- SHOULD include all supported transports for completeness\n- SHOULD include an entry matching the main 'url' and 'preferredTransport'\n- MAY reuse URLs if multiple transports are available at the same endpoint\n- MUST accurately declare the transport available at each URL\n\nClients can select any interface from this list based on their transport capabilities\nand preferences. This enables transport negotiation and fallback scenarios."]
+    #[doc = "DEPRECATED: Use 'supported_interfaces' instead."]
     #[serde(
         rename = "additionalInterfaces",
         default,
         skip_serializing_if = "::std::vec::Vec::is_empty"
     )]
     pub additional_interfaces: ::std::vec::Vec<AgentInterface>,
-    #[doc = "A declaration of optional capabilities supported by the agent."]
+    #[doc = "A2A Capability set supported by the agent."]
     pub capabilities: AgentCapabilities,
-    #[doc = "Default set of supported input MIME types for all skills, which can be\noverridden on a per-skill basis."]
+    #[doc = "protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\n The set of interaction modes that the agent supports across all skills.\n This can be overridden per skill. Defined as media types."]
     #[serde(rename = "defaultInputModes")]
     pub default_input_modes: ::std::vec::Vec<::std::string::String>,
-    #[doc = "Default set of supported output MIME types for all skills, which can be\noverridden on a per-skill basis."]
+    #[doc = "The media types supported as outputs from this agent."]
     #[serde(rename = "defaultOutputModes")]
     pub default_output_modes: ::std::vec::Vec<::std::string::String>,
-    #[doc = "A human-readable description of the agent, assisting users and other agents\nin understanding its purpose."]
+    #[doc = "A human-readable description of the agent, assisting users and other agents\n in understanding its purpose.\n Example: \"Agent that helps users with recipes and cooking.\""]
     pub description: ::std::string::String,
-    #[doc = "An optional URL to the agent's documentation."]
+    #[doc = "A url to provide additional documentation about the agent."]
     #[serde(
         rename = "documentationUrl",
         default,
@@ -528,26 +272,25 @@ pub struct AgentCard {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub icon_url: ::std::option::Option<::std::string::String>,
-    #[doc = "A human-readable name for the agent."]
+    #[doc = "A human readable name for the agent.\n Example: \"Recipe Agent\""]
     pub name: ::std::string::String,
-    #[doc = "The transport protocol for the preferred endpoint (the main 'url' field).\nIf not specified, defaults to 'JSONRPC'.\n\nIMPORTANT: The transport specified here MUST be available at the main 'url'.\nThis creates a binding between the main URL and its supported transport protocol.\nClients should prefer this transport and URL combination when both are supported."]
+    #[doc = "DEPRECATED: Use 'supported_interfaces' instead."]
     #[serde(
         rename = "preferredTransport",
-        default = "defaults::agent_card_preferred_transport"
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
     )]
-    pub preferred_transport: ::std::string::String,
-    #[doc = "The version of the A2A protocol this agent supports."]
+    pub preferred_transport: ::std::option::Option<::std::string::String>,
+    #[doc = "The version of the A2A protocol this agent supports.\n Default: \"1.0\""]
     #[serde(rename = "protocolVersion")]
     pub protocol_version: ::std::string::String,
-    #[doc = "Information about the agent's service provider."]
+    #[doc = "The service provider of the agent."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub provider: ::std::option::Option<AgentProvider>,
-    #[doc = "A list of security requirement objects that apply to all agent interactions. Each object\nlists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object."]
+    #[doc = "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n Security requirements for contacting the agent."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
-    pub security: ::std::vec::Vec<
-        ::std::collections::HashMap<::std::string::String, ::std::vec::Vec<::std::string::String>>,
-    >,
-    #[doc = "A declaration of the security schemes available to authorize requests. The key is the\nscheme name. Follows the OpenAPI 3.0 Security Scheme Object."]
+    pub security: ::std::vec::Vec<Security>,
+    #[doc = "The security scheme details used for authenticating with this agent."]
     #[serde(
         rename = "securitySchemes",
         default,
@@ -557,37 +300,41 @@ pub struct AgentCard {
     #[doc = "JSON Web Signatures computed for this AgentCard."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub signatures: ::std::vec::Vec<AgentCardSignature>,
-    #[doc = "The set of skills, or distinct capabilities, that the agent can perform."]
+    #[doc = "Skills represent an ability of an agent. It is largely\n a descriptive concept but represents a more focused set of behaviors that the\n agent is likely to succeed at."]
     pub skills: ::std::vec::Vec<AgentSkill>,
-    #[doc = "If true, the agent can provide an extended agent card with additional details\nto authenticated users. Defaults to false."]
+    #[doc = "Ordered list of supported interfaces. First entry is preferred."]
     #[serde(
-        rename = "supportsAuthenticatedExtendedCard",
+        rename = "supportedInterfaces",
+        default,
+        skip_serializing_if = "::std::vec::Vec::is_empty"
+    )]
+    pub supported_interfaces: ::std::vec::Vec<AgentInterface>,
+    #[doc = "Whether the agent supports providing an extended agent card when authenticated."]
+    #[serde(
+        rename = "supportsExtendedAgentCard",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
-    pub supports_authenticated_extended_card: ::std::option::Option<bool>,
-    #[doc = "The preferred endpoint URL for interacting with the agent.\nThis URL MUST support the transport specified by 'preferredTransport'."]
-    pub url: ::std::string::String,
-    #[doc = "The agent's own version number. The format is defined by the provider."]
+    pub supports_extended_agent_card: ::std::option::Option<bool>,
+    #[doc = "DEPRECATED: Use 'supported_interfaces' instead."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub url: ::std::option::Option<::std::string::String>,
+    #[doc = "The version of the agent.\n Example: \"1.0.0\""]
     pub version: ::std::string::String,
-}
-impl ::std::convert::From<&AgentCard> for AgentCard {
-    fn from(value: &AgentCard) -> Self {
-        value.clone()
-    }
 }
 impl AgentCard {
     pub fn builder() -> builder::AgentCard {
         Default::default()
     }
 }
-#[doc = "AgentCardSignature represents a JWS signature of an AgentCard.\nThis follows the JSON format of an RFC 7515 JSON Web Signature (JWS)."]
+#[doc = "AgentCardSignature represents a JWS signature of an AgentCard.\n This follows the JSON format of an RFC 7515 JSON Web Signature (JWS)."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"AgentCardSignature represents a JWS signature of an AgentCard.\\nThis follows the JSON format of an RFC 7515 JSON Web Signature (JWS).\","]
+#[doc = "  \"title\": \"Agent Card Signature\","]
+#[doc = "  \"description\": \"AgentCardSignature represents a JWS signature of an AgentCard.\\n This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"protected\","]
@@ -596,35 +343,32 @@ impl AgentCard {
 #[doc = "  \"properties\": {"]
 #[doc = "    \"header\": {"]
 #[doc = "      \"description\": \"The unprotected JWS header values.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"protected\": {"]
-#[doc = "      \"description\": \"The protected JWS header for the signature. This is a Base64url-encoded\\nJSON object, as per RFC 7515.\","]
+#[doc = "      \"description\": \"The protected JWS header for the signature. This is always a\\n base64url-encoded JSON object. Required.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"signature\": {"]
-#[doc = "      \"description\": \"The computed signature, Base64url-encoded.\","]
+#[doc = "      \"description\": \"The computed signature, base64url-encoded. Required.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentCardSignature {
     #[doc = "The unprotected JWS header values."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub header: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The protected JWS header for the signature. This is a Base64url-encoded\nJSON object, as per RFC 7515."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub header: ::std::option::Option<Struct>,
+    #[doc = "The protected JWS header for the signature. This is always a\n base64url-encoded JSON object. Required."]
     pub protected: ::std::string::String,
-    #[doc = "The computed signature, Base64url-encoded."]
+    #[doc = "The computed signature, base64url-encoded. Required."]
     pub signature: ::std::string::String,
-}
-impl ::std::convert::From<&AgentCardSignature> for AgentCardSignature {
-    fn from(value: &AgentCardSignature) -> Self {
-        value.clone()
-    }
 }
 impl AgentCardSignature {
     pub fn builder() -> builder::AgentCardSignature {
@@ -637,16 +381,12 @@ impl AgentCardSignature {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Agent Extension\","]
 #[doc = "  \"description\": \"A declaration of a protocol extension supported by an Agent.\","]
-#[doc = "  \"examples\": ["]
-#[doc = "    {"]
-#[doc = "      \"description\": \"Google OAuth 2.0 authentication\","]
-#[doc = "      \"required\": false,"]
-#[doc = "      \"uri\": \"https://developers.google.com/identity/protocols/oauth2\""]
-#[doc = "    }"]
-#[doc = "  ],"]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
+#[doc = "    \"description\","]
+#[doc = "    \"required\","]
 #[doc = "    \"uri\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
@@ -656,91 +396,83 @@ impl AgentCardSignature {
 #[doc = "    },"]
 #[doc = "    \"params\": {"]
 #[doc = "      \"description\": \"Optional, extension-specific configuration parameters.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"required\": {"]
-#[doc = "      \"description\": \"If true, the client must understand and comply with the extension's requirements\\nto interact with the agent.\","]
+#[doc = "      \"description\": \"If true, the client must understand and comply with the extension's requirements.\","]
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    },"]
 #[doc = "    \"uri\": {"]
 #[doc = "      \"description\": \"The unique URI identifying the extension.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentExtension {
     #[doc = "A human-readable description of how this agent uses the extension."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub description: ::std::option::Option<::std::string::String>,
+    pub description: ::std::string::String,
     #[doc = "Optional, extension-specific configuration parameters."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub params: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "If true, the client must understand and comply with the extension's requirements\nto interact with the agent."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub required: ::std::option::Option<bool>,
+    pub params: ::std::option::Option<Struct>,
+    #[doc = "If true, the client must understand and comply with the extension's requirements."]
+    pub required: bool,
     #[doc = "The unique URI identifying the extension."]
     pub uri: ::std::string::String,
-}
-impl ::std::convert::From<&AgentExtension> for AgentExtension {
-    fn from(value: &AgentExtension) -> Self {
-        value.clone()
-    }
 }
 impl AgentExtension {
     pub fn builder() -> builder::AgentExtension {
         Default::default()
     }
 }
-#[doc = "Declares a combination of a target URL and a transport protocol for interacting with the agent.\nThis allows agents to expose the same functionality over multiple transport mechanisms."]
+#[doc = "Declares a combination of a target URL and a transport protocol for interacting with the agent.\n This allows agents to expose the same functionality over multiple protocol binding mechanisms."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Declares a combination of a target URL and a transport protocol for interacting with the agent.\\nThis allows agents to expose the same functionality over multiple transport mechanisms.\","]
+#[doc = "  \"title\": \"Agent Interface\","]
+#[doc = "  \"description\": \"Declares a combination of a target URL and a transport protocol for interacting with the agent.\\n This allows agents to expose the same functionality over multiple protocol binding mechanisms.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"transport\","]
+#[doc = "    \"protocolBinding\","]
 #[doc = "    \"url\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"transport\": {"]
-#[doc = "      \"description\": \"The transport protocol supported at this URL.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"JSONRPC\","]
-#[doc = "        \"GRPC\","]
-#[doc = "        \"HTTP+JSON\""]
-#[doc = "      ],"]
+#[doc = "    \"protocolBinding\": {"]
+#[doc = "      \"description\": \"The protocol binding supported at this URL. This is an open form string, to be\\n easily extended for other protocol bindings. The core ones officially\\n supported are `JSONRPC`, `GRPC` and `HTTP+JSON`.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Tenant to be set in the request when calling the agent.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"url\": {"]
-#[doc = "      \"description\": \"The URL where this interface is available. Must be a valid absolute HTTPS URL in production.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"https://api.example.com/a2a/v1\","]
-#[doc = "        \"https://grpc.example.com/a2a\","]
-#[doc = "        \"https://rest.example.com/v1\""]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"The URL where this interface is available. Must be a valid absolute HTTPS URL in production.\\n Example: \\\"https://api.example.com/a2a/v1\\\", \\\"https://grpc.example.com/a2a\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentInterface {
-    #[doc = "The transport protocol supported at this URL."]
-    pub transport: ::std::string::String,
-    #[doc = "The URL where this interface is available. Must be a valid absolute HTTPS URL in production."]
+    #[doc = "The protocol binding supported at this URL. This is an open form string, to be\n easily extended for other protocol bindings. The core ones officially\n supported are `JSONRPC`, `GRPC` and `HTTP+JSON`."]
+    #[serde(rename = "protocolBinding")]
+    pub protocol_binding: ::std::string::String,
+    #[doc = "Tenant to be set in the request when calling the agent."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub tenant: ::std::option::Option<::std::string::String>,
+    #[doc = "The URL where this interface is available. Must be a valid absolute HTTPS URL in production.\n Example: \"https://api.example.com/a2a/v1\", \"https://grpc.example.com/a2a\""]
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&AgentInterface> for AgentInterface {
-    fn from(value: &AgentInterface) -> Self {
-        value.clone()
-    }
 }
 impl AgentInterface {
     pub fn builder() -> builder::AgentInterface {
@@ -753,13 +485,8 @@ impl AgentInterface {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Agent Provider\","]
 #[doc = "  \"description\": \"Represents the service provider of an agent.\","]
-#[doc = "  \"examples\": ["]
-#[doc = "    {"]
-#[doc = "      \"organization\": \"Google\","]
-#[doc = "      \"url\": \"https://ai.google.dev\""]
-#[doc = "    }"]
-#[doc = "  ],"]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"organization\","]
@@ -767,28 +494,26 @@ impl AgentInterface {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"organization\": {"]
-#[doc = "      \"description\": \"The name of the agent provider's organization.\","]
+#[doc = "      \"description\": \"The name of the agent provider's organization.\\n Example: \\\"Google\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"url\": {"]
-#[doc = "      \"description\": \"A URL for the agent provider's website or relevant documentation.\","]
+#[doc = "      \"description\": \"A URL for the agent provider's website or relevant documentation.\\n Example: \\\"https://ai.google.dev\\\"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentProvider {
-    #[doc = "The name of the agent provider's organization."]
+    #[doc = "The name of the agent provider's organization.\n Example: \"Google\""]
     pub organization: ::std::string::String,
-    #[doc = "A URL for the agent provider's website or relevant documentation."]
+    #[doc = "A URL for the agent provider's website or relevant documentation.\n Example: \"https://ai.google.dev\""]
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&AgentProvider> for AgentProvider {
-    fn from(value: &AgentProvider) -> Self {
-        value.clone()
-    }
 }
 impl AgentProvider {
     pub fn builder() -> builder::AgentProvider {
@@ -801,6 +526,7 @@ impl AgentProvider {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Agent Skill\","]
 #[doc = "  \"description\": \"Represents a distinct capability or function that an agent can perform.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
@@ -811,16 +537,11 @@ impl AgentProvider {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"description\": {"]
-#[doc = "      \"description\": \"A detailed description of the skill, intended to help clients or users\\nunderstand its purpose and functionality.\","]
+#[doc = "      \"description\": \"A detailed description of the skill.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"examples\": {"]
-#[doc = "      \"description\": \"Example prompts or scenarios that this skill can handle. Provides a hint to\\nthe client on how to use the skill.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        ["]
-#[doc = "          \"I need a recipe for bread\""]
-#[doc = "        ]"]
-#[doc = "      ],"]
+#[doc = "      \"description\": \"Example prompts or scenarios that this skill can handle.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
@@ -831,7 +552,7 @@ impl AgentProvider {
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"inputModes\": {"]
-#[doc = "      \"description\": \"The set of supported input MIME types for this skill, overriding the agent's defaults.\","]
+#[doc = "      \"description\": \"The set of supported input media types for this skill, overriding the agent's defaults.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
@@ -842,40 +563,43 @@ impl AgentProvider {
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"outputModes\": {"]
-#[doc = "      \"description\": \"The set of supported output MIME types for this skill, overriding the agent's defaults.\","]
+#[doc = "      \"description\": \"The set of supported output media types for this skill, overriding the agent's defaults.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
+#[doc = "    \"security\": {"]
+#[doc = "      \"description\": \"protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\\n Security schemes necessary for this skill.\","]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/definitions/Security\""]
+#[doc = "      }"]
+#[doc = "    },"]
 #[doc = "    \"tags\": {"]
 #[doc = "      \"description\": \"A set of keywords describing the skill's capabilities.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        ["]
-#[doc = "          \"cooking\","]
-#[doc = "          \"customer support\","]
-#[doc = "          \"billing\""]
-#[doc = "        ]"]
-#[doc = "      ],"]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AgentSkill {
-    #[doc = "A detailed description of the skill, intended to help clients or users\nunderstand its purpose and functionality."]
+    #[doc = "A detailed description of the skill."]
     pub description: ::std::string::String,
-    #[doc = "Example prompts or scenarios that this skill can handle. Provides a hint to\nthe client on how to use the skill."]
+    #[doc = "Example prompts or scenarios that this skill can handle."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub examples: ::std::vec::Vec<::std::string::String>,
     #[doc = "A unique identifier for the agent's skill."]
     pub id: ::std::string::String,
-    #[doc = "The set of supported input MIME types for this skill, overriding the agent's defaults."]
+    #[doc = "The set of supported input media types for this skill, overriding the agent's defaults."]
     #[serde(
         rename = "inputModes",
         default,
@@ -884,20 +608,18 @@ pub struct AgentSkill {
     pub input_modes: ::std::vec::Vec<::std::string::String>,
     #[doc = "A human-readable name for the skill."]
     pub name: ::std::string::String,
-    #[doc = "The set of supported output MIME types for this skill, overriding the agent's defaults."]
+    #[doc = "The set of supported output media types for this skill, overriding the agent's defaults."]
     #[serde(
         rename = "outputModes",
         default,
         skip_serializing_if = "::std::vec::Vec::is_empty"
     )]
     pub output_modes: ::std::vec::Vec<::std::string::String>,
+    #[doc = "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n Security schemes necessary for this skill."]
+    #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+    pub security: ::std::vec::Vec<Security>,
     #[doc = "A set of keywords describing the skill's capabilities."]
     pub tags: ::std::vec::Vec<::std::string::String>,
-}
-impl ::std::convert::From<&AgentSkill> for AgentSkill {
-    fn from(value: &AgentSkill) -> Self {
-        value.clone()
-    }
 }
 impl AgentSkill {
     pub fn builder() -> builder::AgentSkill {
@@ -910,154 +632,56 @@ impl AgentSkill {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"API Key Security Scheme\","]
 #[doc = "  \"description\": \"Defines a security scheme using an API key.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"in\","]
-#[doc = "    \"name\","]
-#[doc = "    \"type\""]
+#[doc = "    \"location\","]
+#[doc = "    \"name\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"description\": {"]
 #[doc = "      \"description\": \"An optional description for the security scheme.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"in\": {"]
-#[doc = "      \"description\": \"The location of the API key.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"enum\": ["]
-#[doc = "        \"cookie\","]
-#[doc = "        \"header\","]
-#[doc = "        \"query\""]
-#[doc = "      ]"]
+#[doc = "    \"location\": {"]
+#[doc = "      \"description\": \"The location of the API key. Valid values are \\\"query\\\", \\\"header\\\", or \\\"cookie\\\".\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"name\": {"]
 #[doc = "      \"description\": \"The name of the header, query, or cookie parameter to be used.\","]
 #[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"type\": {"]
-#[doc = "      \"description\": \"The type of the security scheme. Must be 'apiKey'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"apiKey\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ApiKeySecurityScheme {
     #[doc = "An optional description for the security scheme."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[doc = "The location of the API key."]
-    #[serde(rename = "in")]
-    pub in_: ApiKeySecuritySchemeIn,
+    #[doc = "The location of the API key. Valid values are \"query\", \"header\", or \"cookie\"."]
+    pub location: ::std::string::String,
     #[doc = "The name of the header, query, or cookie parameter to be used."]
     pub name: ::std::string::String,
-    #[doc = "The type of the security scheme. Must be 'apiKey'."]
-    #[serde(rename = "type")]
-    pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&ApiKeySecurityScheme> for ApiKeySecurityScheme {
-    fn from(value: &ApiKeySecurityScheme) -> Self {
-        value.clone()
-    }
 }
 impl ApiKeySecurityScheme {
     pub fn builder() -> builder::ApiKeySecurityScheme {
         Default::default()
     }
 }
-#[doc = "The location of the API key."]
+#[doc = "Artifacts represent task outputs."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The location of the API key.\","]
-#[doc = "  \"type\": \"string\","]
-#[doc = "  \"enum\": ["]
-#[doc = "    \"cookie\","]
-#[doc = "    \"header\","]
-#[doc = "    \"query\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(
-    :: serde :: Deserialize,
-    :: serde :: Serialize,
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-)]
-pub enum ApiKeySecuritySchemeIn {
-    #[serde(rename = "cookie")]
-    Cookie,
-    #[serde(rename = "header")]
-    Header,
-    #[serde(rename = "query")]
-    Query,
-}
-impl ::std::convert::From<&Self> for ApiKeySecuritySchemeIn {
-    fn from(value: &ApiKeySecuritySchemeIn) -> Self {
-        value.clone()
-    }
-}
-impl ::std::fmt::Display for ApiKeySecuritySchemeIn {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match *self {
-            Self::Cookie => write!(f, "cookie"),
-            Self::Header => write!(f, "header"),
-            Self::Query => write!(f, "query"),
-        }
-    }
-}
-impl ::std::str::FromStr for ApiKeySecuritySchemeIn {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        match value {
-            "cookie" => Ok(Self::Cookie),
-            "header" => Ok(Self::Header),
-            "query" => Ok(Self::Query),
-            _ => Err("invalid value".into()),
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for ApiKeySecuritySchemeIn {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ApiKeySecuritySchemeIn {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for ApiKeySecuritySchemeIn {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-#[doc = "Represents a file, data structure, or other resource generated by an agent during a task."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a file, data structure, or other resource generated by an agent during a task.\","]
+#[doc = "  \"title\": \"Artifact\","]
+#[doc = "  \"description\": \"Artifacts represent task outputs.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"artifactId\","]
@@ -1065,67 +689,108 @@ impl ::std::convert::TryFrom<::std::string::String> for ApiKeySecuritySchemeIn {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"artifactId\": {"]
-#[doc = "      \"description\": \"A unique identifier for the artifact within the scope of the task.\","]
+#[doc = "      \"description\": \"Unique identifier (e.g. UUID) for the artifact. It must be at least unique\\n within a task.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"description\": {"]
-#[doc = "      \"description\": \"An optional, human-readable description of the artifact.\","]
+#[doc = "      \"description\": \"A human readable description of the artifact, optional.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"extensions\": {"]
-#[doc = "      \"description\": \"The URIs of extensions that are relevant to this artifact.\","]
+#[doc = "      \"description\": \"The URIs of extensions that are present or contributed to this Artifact.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata for extensions. The key is an extension-specific identifier.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"description\": \"Optional metadata included with the artifact.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"name\": {"]
-#[doc = "      \"description\": \"An optional, human-readable name for the artifact.\","]
+#[doc = "      \"description\": \"A human readable name for the artifact.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"parts\": {"]
-#[doc = "      \"description\": \"An array of content parts that make up the artifact.\","]
+#[doc = "      \"description\": \"The content of the artifact. Must contain at least one part.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/Part\""]
 #[doc = "      }"]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Artifact {
-    #[doc = "A unique identifier for the artifact within the scope of the task."]
+    #[doc = "Unique identifier (e.g. UUID) for the artifact. It must be at least unique\n within a task."]
     #[serde(rename = "artifactId")]
     pub artifact_id: ::std::string::String,
-    #[doc = "An optional, human-readable description of the artifact."]
+    #[doc = "A human readable description of the artifact, optional."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[doc = "The URIs of extensions that are relevant to this artifact."]
+    #[doc = "The URIs of extensions that are present or contributed to this Artifact."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub extensions: ::std::vec::Vec<::std::string::String>,
-    #[doc = "Optional metadata for extensions. The key is an extension-specific identifier."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "An optional, human-readable name for the artifact."]
+    #[doc = "Optional metadata included with the artifact."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
+    #[doc = "A human readable name for the artifact."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub name: ::std::option::Option<::std::string::String>,
-    #[doc = "An array of content parts that make up the artifact."]
+    #[doc = "The content of the artifact. Must contain at least one part."]
     pub parts: ::std::vec::Vec<Part>,
-}
-impl ::std::convert::From<&Artifact> for Artifact {
-    fn from(value: &Artifact) -> Self {
-        value.clone()
-    }
 }
 impl Artifact {
     pub fn builder() -> builder::Artifact {
+        Default::default()
+    }
+}
+#[doc = "Defines authentication details, used for push notifications."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Authentication Info\","]
+#[doc = "  \"description\": \"Defines authentication details, used for push notifications.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"schemes\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"credentials\": {"]
+#[doc = "      \"description\": \"Optional credentials\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"schemes\": {"]
+#[doc = "      \"description\": \"A list of supported authentication schemes (e.g., 'Basic', 'Bearer').\","]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AuthenticationInfo {
+    #[doc = "Optional credentials"]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub credentials: ::std::option::Option<::std::string::String>,
+    #[doc = "A list of supported authentication schemes (e.g., 'Basic', 'Bearer')."]
+    pub schemes: ::std::vec::Vec<::std::string::String>,
+}
+impl AuthenticationInfo {
+    pub fn builder() -> builder::AuthenticationInfo {
         Default::default()
     }
 }
@@ -1135,6 +800,7 @@ impl Artifact {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Authorization CodeO Auth Flow\","]
 #[doc = "  \"description\": \"Defines configuration details for the OAuth 2.0 Authorization Code flow.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
@@ -1144,312 +810,96 @@ impl Artifact {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"authorizationUrl\": {"]
-#[doc = "      \"description\": \"The authorization URL to be used for this flow.\\nThis MUST be a URL and use TLS.\","]
+#[doc = "      \"description\": \"The authorization URL to be used for this flow.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"refreshUrl\": {"]
-#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens.\\nThis MUST be a URL and use TLS.\","]
+#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"scopes\": {"]
-#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme. A map between the scope\\nname and a short description for it.\","]
+#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme.\","]
 #[doc = "      \"type\": \"object\","]
 #[doc = "      \"additionalProperties\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      },"]
+#[doc = "      \"propertyNames\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"tokenUrl\": {"]
-#[doc = "      \"description\": \"The token URL to be used for this flow.\\nThis MUST be a URL and use TLS.\","]
+#[doc = "      \"description\": \"The token URL to be used for this flow.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AuthorizationCodeOAuthFlow {
-    #[doc = "The authorization URL to be used for this flow.\nThis MUST be a URL and use TLS."]
+    #[doc = "The authorization URL to be used for this flow."]
     #[serde(rename = "authorizationUrl")]
     pub authorization_url: ::std::string::String,
-    #[doc = "The URL to be used for obtaining refresh tokens.\nThis MUST be a URL and use TLS."]
+    #[doc = "The URL to be used for obtaining refresh tokens."]
     #[serde(
         rename = "refreshUrl",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub refresh_url: ::std::option::Option<::std::string::String>,
-    #[doc = "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it."]
+    #[doc = "The available scopes for the OAuth2 security scheme."]
     pub scopes: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
-    #[doc = "The token URL to be used for this flow.\nThis MUST be a URL and use TLS."]
+    #[doc = "The token URL to be used for this flow."]
     #[serde(rename = "tokenUrl")]
     pub token_url: ::std::string::String,
-}
-impl ::std::convert::From<&AuthorizationCodeOAuthFlow> for AuthorizationCodeOAuthFlow {
-    fn from(value: &AuthorizationCodeOAuthFlow) -> Self {
-        value.clone()
-    }
 }
 impl AuthorizationCodeOAuthFlow {
     pub fn builder() -> builder::AuthorizationCodeOAuthFlow {
         Default::default()
     }
 }
-#[doc = "Represents a JSON-RPC request for the `tasks/cancel` method."]
+#[doc = "Represents a request for the `tasks/cancel` method."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/cancel` method.\","]
+#[doc = "  \"title\": \"Cancel Task Request\","]
+#[doc = "  \"description\": \"Represents a request for the `tasks/cancel` method.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
+#[doc = "    \"name\","]
+#[doc = "    \"tenant\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
+#[doc = "    \"name\": {"]
+#[doc = "      \"description\": \"The resource name of the task to cancel.\\n Format: tasks/{task_id}\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/cancel'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/cancel\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters identifying the task to cancel.\","]
-#[doc = "      \"$ref\": \"#/definitions/TaskIdParams\""]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct CancelTaskRequest {
-    #[doc = "The identifier for this request."]
-    pub id: CancelTaskRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/cancel'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters identifying the task to cancel."]
-    pub params: TaskIdParams,
-}
-impl ::std::convert::From<&CancelTaskRequest> for CancelTaskRequest {
-    fn from(value: &CancelTaskRequest) -> Self {
-        value.clone()
-    }
+    #[doc = "The resource name of the task to cancel.\n Format: tasks/{task_id}"]
+    pub name: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
 impl CancelTaskRequest {
     pub fn builder() -> builder::CancelTaskRequest {
         Default::default()
-    }
-}
-#[doc = "The identifier for this request."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum CancelTaskRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for CancelTaskRequestId {
-    fn from(value: &CancelTaskRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for CancelTaskRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for CancelTaskRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for CancelTaskRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for CancelTaskRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for CancelTaskRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for CancelTaskRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `tasks/cancel` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `tasks/cancel` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/CancelTaskSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum CancelTaskResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    CancelTaskSuccessResponse(CancelTaskSuccessResponse),
-}
-impl ::std::convert::From<&Self> for CancelTaskResponse {
-    fn from(value: &CancelTaskResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for CancelTaskResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<CancelTaskSuccessResponse> for CancelTaskResponse {
-    fn from(value: CancelTaskSuccessResponse) -> Self {
-        Self::CancelTaskSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `tasks/cancel` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `tasks/cancel` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, containing the final state of the canceled Task object.\","]
-#[doc = "      \"$ref\": \"#/definitions/Task\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct CancelTaskSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: CancelTaskSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, containing the final state of the canceled Task object."]
-    pub result: Task,
-}
-impl ::std::convert::From<&CancelTaskSuccessResponse> for CancelTaskSuccessResponse {
-    fn from(value: &CancelTaskSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl CancelTaskSuccessResponse {
-    pub fn builder() -> builder::CancelTaskSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum CancelTaskSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for CancelTaskSuccessResponseId {
-    fn from(value: &CancelTaskSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for CancelTaskSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
     }
 }
 #[doc = "Defines configuration details for the OAuth 2.0 Client Credentials flow."]
@@ -1458,6 +908,7 @@ impl ::std::convert::From<i64> for CancelTaskSuccessResponseId {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Client CredentialsO Auth Flow\","]
 #[doc = "  \"description\": \"Defines configuration details for the OAuth 2.0 Client Credentials flow.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
@@ -1466,1361 +917,386 @@ impl ::std::convert::From<i64> for CancelTaskSuccessResponseId {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"refreshUrl\": {"]
-#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens. This MUST be a URL.\","]
+#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"scopes\": {"]
-#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme. A map between the scope\\nname and a short description for it.\","]
+#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme.\","]
 #[doc = "      \"type\": \"object\","]
 #[doc = "      \"additionalProperties\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      },"]
+#[doc = "      \"propertyNames\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"tokenUrl\": {"]
-#[doc = "      \"description\": \"The token URL to be used for this flow. This MUST be a URL.\","]
+#[doc = "      \"description\": \"The token URL to be used for this flow.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ClientCredentialsOAuthFlow {
-    #[doc = "The URL to be used for obtaining refresh tokens. This MUST be a URL."]
+    #[doc = "The URL to be used for obtaining refresh tokens."]
     #[serde(
         rename = "refreshUrl",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub refresh_url: ::std::option::Option<::std::string::String>,
-    #[doc = "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it."]
+    #[doc = "The available scopes for the OAuth2 security scheme."]
     pub scopes: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
-    #[doc = "The token URL to be used for this flow. This MUST be a URL."]
+    #[doc = "The token URL to be used for this flow."]
     #[serde(rename = "tokenUrl")]
     pub token_url: ::std::string::String,
-}
-impl ::std::convert::From<&ClientCredentialsOAuthFlow> for ClientCredentialsOAuthFlow {
-    fn from(value: &ClientCredentialsOAuthFlow) -> Self {
-        value.clone()
-    }
 }
 impl ClientCredentialsOAuthFlow {
     pub fn builder() -> builder::ClientCredentialsOAuthFlow {
         Default::default()
     }
 }
-#[doc = "An A2A-specific error indicating an incompatibility between the requested\ncontent types and the agent's capabilities."]
+#[doc = "DataPart represents a structured blob."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"An A2A-specific error indicating an incompatibility between the requested\\ncontent types and the agent's capabilities.\","]
+#[doc = "  \"title\": \"Data Part\","]
+#[doc = "  \"description\": \"DataPart represents a structured blob.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
+#[doc = "    \"data\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for an unsupported content type.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32005"]
-#[doc = "    },"]
 #[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Incompatible content types\","]
-#[doc = "      \"type\": \"string\""]
+#[doc = "      \"description\": \"A JSON object containing arbitrary data.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct ContentTypeNotSupportedError {
-    #[doc = "The error code for an unsupported content type."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&ContentTypeNotSupportedError> for ContentTypeNotSupportedError {
-    fn from(value: &ContentTypeNotSupportedError) -> Self {
-        value.clone()
-    }
-}
-impl ContentTypeNotSupportedError {
-    pub fn builder() -> builder::ContentTypeNotSupportedError {
-        Default::default()
-    }
-}
-#[doc = "Represents a structured data segment (e.g., JSON) within a message or artifact."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a structured data segment (e.g., JSON) within a message or artifact.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"data\","]
-#[doc = "    \"kind\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"The structured data content.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    },"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this part, used as a discriminator. Always 'data'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"data\""]
-#[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with this part.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DataPart {
-    #[doc = "The structured data content."]
-    pub data: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The type of this part, used as a discriminator. Always 'data'."]
-    pub kind: ::std::string::String,
-    #[doc = "Optional metadata associated with this part."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&DataPart> for DataPart {
-    fn from(value: &DataPart) -> Self {
-        value.clone()
-    }
+    #[doc = "A JSON object containing arbitrary data."]
+    pub data: Struct,
 }
 impl DataPart {
     pub fn builder() -> builder::DataPart {
         Default::default()
     }
 }
-#[doc = "Defines parameters for deleting a specific push notification configuration for a task."]
+#[doc = "Represents a request for the `tasks/pushNotificationConfig/delete` method."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Defines parameters for deleting a specific push notification configuration for a task.\","]
+#[doc = "  \"title\": \"Delete Task Push Notification Config Request\","]
+#[doc = "  \"description\": \"Represents a request for the `tasks/pushNotificationConfig/delete` method.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"pushNotificationConfigId\""]
+#[doc = "    \"name\","]
+#[doc = "    \"tenant\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The unique identifier of the task.\","]
+#[doc = "    \"name\": {"]
+#[doc = "      \"description\": \"The resource name of the config to delete.\\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with the request.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    },"]
-#[doc = "    \"pushNotificationConfigId\": {"]
-#[doc = "      \"description\": \"The ID of the push notification configuration to delete.\","]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct DeleteTaskPushNotificationConfigParams {
-    #[doc = "The unique identifier of the task."]
-    pub id: ::std::string::String,
-    #[doc = "Optional metadata associated with the request."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The ID of the push notification configuration to delete."]
-    #[serde(rename = "pushNotificationConfigId")]
-    pub push_notification_config_id: ::std::string::String,
-}
-impl ::std::convert::From<&DeleteTaskPushNotificationConfigParams>
-    for DeleteTaskPushNotificationConfigParams
-{
-    fn from(value: &DeleteTaskPushNotificationConfigParams) -> Self {
-        value.clone()
-    }
-}
-impl DeleteTaskPushNotificationConfigParams {
-    pub fn builder() -> builder::DeleteTaskPushNotificationConfigParams {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/delete` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/pushNotificationConfig/delete` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/pushNotificationConfig/delete'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/pushNotificationConfig/delete\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters identifying the push notification configuration to delete.\","]
-#[doc = "      \"$ref\": \"#/definitions/DeleteTaskPushNotificationConfigParams\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DeleteTaskPushNotificationConfigRequest {
-    #[doc = "The identifier for this request."]
-    pub id: DeleteTaskPushNotificationConfigRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/pushNotificationConfig/delete'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters identifying the push notification configuration to delete."]
-    pub params: DeleteTaskPushNotificationConfigParams,
-}
-impl ::std::convert::From<&DeleteTaskPushNotificationConfigRequest>
-    for DeleteTaskPushNotificationConfigRequest
-{
-    fn from(value: &DeleteTaskPushNotificationConfigRequest) -> Self {
-        value.clone()
-    }
+    #[doc = "The resource name of the config to delete.\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}"]
+    pub name: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
 impl DeleteTaskPushNotificationConfigRequest {
     pub fn builder() -> builder::DeleteTaskPushNotificationConfigRequest {
         Default::default()
     }
 }
-#[doc = "The identifier for this request."]
+#[doc = "FilePart represents the different ways files can be provided. If files are\n small, directly feeding the bytes is supported via file_with_bytes. If the\n file is large, the agent should read the content as appropriate directly\n from the file_with_uri source."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum DeleteTaskPushNotificationConfigRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for DeleteTaskPushNotificationConfigRequestId {
-    fn from(value: &DeleteTaskPushNotificationConfigRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for DeleteTaskPushNotificationConfigRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for DeleteTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for DeleteTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for DeleteTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for DeleteTaskPushNotificationConfigRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for DeleteTaskPushNotificationConfigRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/delete` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/DeleteTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum DeleteTaskPushNotificationConfigResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    DeleteTaskPushNotificationConfigSuccessResponse(
-        DeleteTaskPushNotificationConfigSuccessResponse,
-    ),
-}
-impl ::std::convert::From<&Self> for DeleteTaskPushNotificationConfigResponse {
-    fn from(value: &DeleteTaskPushNotificationConfigResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for DeleteTaskPushNotificationConfigResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<DeleteTaskPushNotificationConfigSuccessResponse>
-    for DeleteTaskPushNotificationConfigResponse
-{
-    fn from(value: DeleteTaskPushNotificationConfigSuccessResponse) -> Self {
-        Self::DeleteTaskPushNotificationConfigSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/delete` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.\","]
+#[doc = "  \"title\": \"File Part\","]
+#[doc = "  \"description\": \"FilePart represents the different ways files can be provided. If files are\\n small, directly feeding the bytes is supported via file_with_bytes. If the\\n file is large, the agent should read the content as appropriate directly\\n from the file_with_uri source.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
+#[doc = "    \"mediaType\","]
+#[doc = "    \"name\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
+#[doc = "    \"fileWithBytes\": {"]
+#[doc = "      \"description\": \"The base64-encoded content of the file.\","]
 #[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
+#[doc = "      \"pattern\": \"^[A-Za-z0-9+/]*={0,2}$\""]
 #[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result is null on successful deletion.\","]
-#[doc = "      \"type\": \"null\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct DeleteTaskPushNotificationConfigSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: DeleteTaskPushNotificationConfigSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result is null on successful deletion."]
-    pub result: (),
-}
-impl ::std::convert::From<&DeleteTaskPushNotificationConfigSuccessResponse>
-    for DeleteTaskPushNotificationConfigSuccessResponse
-{
-    fn from(value: &DeleteTaskPushNotificationConfigSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl DeleteTaskPushNotificationConfigSuccessResponse {
-    pub fn builder() -> builder::DeleteTaskPushNotificationConfigSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum DeleteTaskPushNotificationConfigSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for DeleteTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: &DeleteTaskPushNotificationConfigSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for DeleteTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Defines base properties for a file."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines base properties for a file.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"mimeType\": {"]
-#[doc = "      \"description\": \"The MIME type of the file (e.g., \\\"application/pdf\\\").\","]
+#[doc = "    \"fileWithUri\": {"]
+#[doc = "      \"description\": \"A URL pointing to the file's content.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"mediaType\": {"]
+#[doc = "      \"description\": \"The media type of the file (e.g., \\\"application/pdf\\\").\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"name\": {"]
 #[doc = "      \"description\": \"An optional name for the file (e.g., \\\"document.pdf\\\").\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct FileBase {
-    #[doc = "The MIME type of the file (e.g., \"application/pdf\")."]
+#[serde(deny_unknown_fields)]
+pub struct FilePart {
+    #[doc = "The base64-encoded content of the file."]
     #[serde(
-        rename = "mimeType",
+        rename = "fileWithBytes",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
-    pub mime_type: ::std::option::Option<::std::string::String>,
+    pub file_with_bytes: ::std::option::Option<FilePartFileWithBytes>,
+    #[doc = "A URL pointing to the file's content."]
+    #[serde(
+        rename = "fileWithUri",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub file_with_uri: ::std::option::Option<::std::string::String>,
+    #[doc = "The media type of the file (e.g., \"application/pdf\")."]
+    #[serde(rename = "mediaType")]
+    pub media_type: ::std::string::String,
     #[doc = "An optional name for the file (e.g., \"document.pdf\")."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub name: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&FileBase> for FileBase {
-    fn from(value: &FileBase) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for FileBase {
-    fn default() -> Self {
-        Self {
-            mime_type: Default::default(),
-            name: Default::default(),
-        }
-    }
-}
-impl FileBase {
-    pub fn builder() -> builder::FileBase {
-        Default::default()
-    }
-}
-#[doc = "Represents a file segment within a message or artifact. The file content can be\nprovided either directly as bytes or as a URI."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a file segment within a message or artifact. The file content can be\\nprovided either directly as bytes or as a URI.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"file\","]
-#[doc = "    \"kind\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"file\": {"]
-#[doc = "      \"description\": \"The file content, represented as either a URI or as base64-encoded bytes.\","]
-#[doc = "      \"anyOf\": ["]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/FileWithBytes\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/FileWithUri\""]
-#[doc = "        }"]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this part, used as a discriminator. Always 'file'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"file\""]
-#[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with this part.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct FilePart {
-    #[doc = "The file content, represented as either a URI or as base64-encoded bytes."]
-    pub file: FilePartFile,
-    #[doc = "The type of this part, used as a discriminator. Always 'file'."]
-    pub kind: ::std::string::String,
-    #[doc = "Optional metadata associated with this part."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&FilePart> for FilePart {
-    fn from(value: &FilePart) -> Self {
-        value.clone()
-    }
+    pub name: ::std::string::String,
 }
 impl FilePart {
     pub fn builder() -> builder::FilePart {
         Default::default()
     }
 }
-#[doc = "The file content, represented as either a URI or as base64-encoded bytes."]
+#[doc = "The base64-encoded content of the file."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The file content, represented as either a URI or as base64-encoded bytes.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/FileWithBytes\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/FileWithUri\""]
+#[doc = "  \"description\": \"The base64-encoded content of the file.\","]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"pattern\": \"^[A-Za-z0-9+/]*={0,2}$\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct FilePartFileWithBytes(::std::string::String);
+impl ::std::ops::Deref for FilePartFileWithBytes {
+    type Target = ::std::string::String;
+    fn deref(&self) -> &::std::string::String {
+        &self.0
+    }
+}
+impl ::std::convert::From<FilePartFileWithBytes> for ::std::string::String {
+    fn from(value: FilePartFileWithBytes) -> Self {
+        value.0
+    }
+}
+impl ::std::str::FromStr for FilePartFileWithBytes {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
+            ::std::sync::LazyLock::new(|| ::regress::Regex::new("^[A-Za-z0-9+/]*={0,2}$").unwrap());
+        if PATTERN.find(value).is_none() {
+            return Err("doesn't match pattern \"^[A-Za-z0-9+/]*={0,2}$\"".into());
+        }
+        Ok(Self(value.to_string()))
+    }
+}
+impl ::std::convert::TryFrom<&str> for FilePartFileWithBytes {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String> for FilePartFileWithBytes {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String> for FilePartFileWithBytes {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl<'de> ::serde::Deserialize<'de> for FilePartFileWithBytes {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        ::std::string::String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as ::serde::de::Error>::custom(e.to_string())
+            })
+    }
+}
+#[doc = "`GetExtendedAgentCardRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Get Extended Agent Card Request\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"tenant\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  ]"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum FilePartFile {
-    Bytes(FileWithBytes),
-    Uri(FileWithUri),
+#[serde(deny_unknown_fields)]
+pub struct GetExtendedAgentCardRequest {
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
-impl ::std::convert::From<&Self> for FilePartFile {
-    fn from(value: &FilePartFile) -> Self {
-        value.clone()
+impl GetExtendedAgentCardRequest {
+    pub fn builder() -> builder::GetExtendedAgentCardRequest {
+        Default::default()
     }
 }
-impl ::std::convert::From<FileWithBytes> for FilePartFile {
-    fn from(value: FileWithBytes) -> Self {
-        Self::Bytes(value)
-    }
-}
-impl ::std::convert::From<FileWithUri> for FilePartFile {
-    fn from(value: FileWithUri) -> Self {
-        Self::Uri(value)
-    }
-}
-#[doc = "Represents a file with its content provided directly as a base64-encoded string."]
+#[doc = "`GetTaskPushNotificationConfigRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a file with its content provided directly as a base64-encoded string.\","]
+#[doc = "  \"title\": \"Get Task Push Notification Config Request\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"bytes\""]
+#[doc = "    \"name\","]
+#[doc = "    \"tenant\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"bytes\": {"]
-#[doc = "      \"description\": \"The base64-encoded content of the file.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"mimeType\": {"]
-#[doc = "      \"description\": \"The MIME type of the file (e.g., \\\"application/pdf\\\").\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
 #[doc = "    \"name\": {"]
-#[doc = "      \"description\": \"An optional name for the file (e.g., \\\"document.pdf\\\").\","]
+#[doc = "      \"description\": \"The resource name of the config to retrieve.\\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct FileWithBytes {
-    #[doc = "The base64-encoded content of the file."]
-    pub bytes: ::std::string::String,
-    #[doc = "The MIME type of the file (e.g., \"application/pdf\")."]
-    #[serde(
-        rename = "mimeType",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub mime_type: ::std::option::Option<::std::string::String>,
-    #[doc = "An optional name for the file (e.g., \"document.pdf\")."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub name: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&FileWithBytes> for FileWithBytes {
-    fn from(value: &FileWithBytes) -> Self {
-        value.clone()
-    }
-}
-impl FileWithBytes {
-    pub fn builder() -> builder::FileWithBytes {
-        Default::default()
-    }
-}
-#[doc = "Represents a file with its content located at a specific URI."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a file with its content located at a specific URI.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"uri\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"mimeType\": {"]
-#[doc = "      \"description\": \"The MIME type of the file (e.g., \\\"application/pdf\\\").\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"name\": {"]
-#[doc = "      \"description\": \"An optional name for the file (e.g., \\\"document.pdf\\\").\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"uri\": {"]
-#[doc = "      \"description\": \"A URL pointing to the file's content.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct FileWithUri {
-    #[doc = "The MIME type of the file (e.g., \"application/pdf\")."]
-    #[serde(
-        rename = "mimeType",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub mime_type: ::std::option::Option<::std::string::String>,
-    #[doc = "An optional name for the file (e.g., \"document.pdf\")."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub name: ::std::option::Option<::std::string::String>,
-    #[doc = "A URL pointing to the file's content."]
-    pub uri: ::std::string::String,
-}
-impl ::std::convert::From<&FileWithUri> for FileWithUri {
-    fn from(value: &FileWithUri) -> Self {
-        value.clone()
-    }
-}
-impl FileWithUri {
-    pub fn builder() -> builder::FileWithUri {
-        Default::default()
-    }
-}
-#[doc = "Defines parameters for fetching a specific push notification configuration for a task."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines parameters for fetching a specific push notification configuration for a task.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The unique identifier of the task.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with the request.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    },"]
-#[doc = "    \"pushNotificationConfigId\": {"]
-#[doc = "      \"description\": \"The ID of the push notification configuration to retrieve.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct GetTaskPushNotificationConfigParams {
-    #[doc = "The unique identifier of the task."]
-    pub id: ::std::string::String,
-    #[doc = "Optional metadata associated with the request."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The ID of the push notification configuration to retrieve."]
-    #[serde(
-        rename = "pushNotificationConfigId",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub push_notification_config_id: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&GetTaskPushNotificationConfigParams>
-    for GetTaskPushNotificationConfigParams
-{
-    fn from(value: &GetTaskPushNotificationConfigParams) -> Self {
-        value.clone()
-    }
-}
-impl GetTaskPushNotificationConfigParams {
-    pub fn builder() -> builder::GetTaskPushNotificationConfigParams {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/get` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/pushNotificationConfig/get` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/pushNotificationConfig/get'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/pushNotificationConfig/get\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters for getting a push notification configuration.\","]
-#[doc = "      \"anyOf\": ["]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/TaskIdParams\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/GetTaskPushNotificationConfigParams\""]
-#[doc = "        }"]
-#[doc = "      ]"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct GetTaskPushNotificationConfigRequest {
-    #[doc = "The identifier for this request."]
-    pub id: GetTaskPushNotificationConfigRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/pushNotificationConfig/get'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters for getting a push notification configuration."]
-    pub params: GetTaskPushNotificationConfigRequestParams,
-}
-impl ::std::convert::From<&GetTaskPushNotificationConfigRequest>
-    for GetTaskPushNotificationConfigRequest
-{
-    fn from(value: &GetTaskPushNotificationConfigRequest) -> Self {
-        value.clone()
-    }
+    #[doc = "The resource name of the config to retrieve.\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}"]
+    pub name: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
 impl GetTaskPushNotificationConfigRequest {
     pub fn builder() -> builder::GetTaskPushNotificationConfigRequest {
         Default::default()
     }
 }
-#[doc = "The identifier for this request."]
+#[doc = "Represents a request for the `tasks/get` method."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GetTaskPushNotificationConfigRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for GetTaskPushNotificationConfigRequestId {
-    fn from(value: &GetTaskPushNotificationConfigRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for GetTaskPushNotificationConfigRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for GetTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for GetTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for GetTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for GetTaskPushNotificationConfigRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for GetTaskPushNotificationConfigRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "The parameters for getting a push notification configuration."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The parameters for getting a push notification configuration.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskIdParams\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskPushNotificationConfigParams\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct GetTaskPushNotificationConfigRequestParams {
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_0: ::std::option::Option<TaskIdParams>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_1: ::std::option::Option<GetTaskPushNotificationConfigParams>,
-}
-impl ::std::convert::From<&GetTaskPushNotificationConfigRequestParams>
-    for GetTaskPushNotificationConfigRequestParams
-{
-    fn from(value: &GetTaskPushNotificationConfigRequestParams) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for GetTaskPushNotificationConfigRequestParams {
-    fn default() -> Self {
-        Self {
-            subtype_0: Default::default(),
-            subtype_1: Default::default(),
-        }
-    }
-}
-impl GetTaskPushNotificationConfigRequestParams {
-    pub fn builder() -> builder::GetTaskPushNotificationConfigRequestParams {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/get` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `tasks/pushNotificationConfig/get` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GetTaskPushNotificationConfigResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    GetTaskPushNotificationConfigSuccessResponse(GetTaskPushNotificationConfigSuccessResponse),
-}
-impl ::std::convert::From<&Self> for GetTaskPushNotificationConfigResponse {
-    fn from(value: &GetTaskPushNotificationConfigResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for GetTaskPushNotificationConfigResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<GetTaskPushNotificationConfigSuccessResponse>
-    for GetTaskPushNotificationConfigResponse
-{
-    fn from(value: GetTaskPushNotificationConfigSuccessResponse) -> Self {
-        Self::GetTaskPushNotificationConfigSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/get` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/get` method.\","]
+#[doc = "  \"title\": \"Get Task Request\","]
+#[doc = "  \"description\": \"Represents a request for the `tasks/get` method.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
+#[doc = "    \"name\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
+#[doc = "    \"historyLength\": {"]
+#[doc = "      \"description\": \"The maximum number of messages to include in the history.\","]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
 #[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
+#[doc = "    \"name\": {"]
+#[doc = "      \"description\": \"The resource name of the task.\\n Format: tasks/{task_id}\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, containing the requested push notification configuration.\","]
-#[doc = "      \"$ref\": \"#/definitions/TaskPushNotificationConfig\""]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct GetTaskPushNotificationConfigSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: GetTaskPushNotificationConfigSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, containing the requested push notification configuration."]
-    pub result: TaskPushNotificationConfig,
-}
-impl ::std::convert::From<&GetTaskPushNotificationConfigSuccessResponse>
-    for GetTaskPushNotificationConfigSuccessResponse
-{
-    fn from(value: &GetTaskPushNotificationConfigSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl GetTaskPushNotificationConfigSuccessResponse {
-    pub fn builder() -> builder::GetTaskPushNotificationConfigSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GetTaskPushNotificationConfigSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for GetTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: &GetTaskPushNotificationConfigSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for GetTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `tasks/get` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/get` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/get'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/get\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters for querying a task.\","]
-#[doc = "      \"$ref\": \"#/definitions/TaskQueryParams\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct GetTaskRequest {
-    #[doc = "The identifier for this request."]
-    pub id: GetTaskRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/get'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters for querying a task."]
-    pub params: TaskQueryParams,
-}
-impl ::std::convert::From<&GetTaskRequest> for GetTaskRequest {
-    fn from(value: &GetTaskRequest) -> Self {
-        value.clone()
-    }
+    #[doc = "The maximum number of messages to include in the history."]
+    #[serde(
+        rename = "historyLength",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub history_length: ::std::option::Option<i32>,
+    #[doc = "The resource name of the task.\n Format: tasks/{task_id}"]
+    pub name: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub tenant: ::std::option::Option<::std::string::String>,
 }
 impl GetTaskRequest {
     pub fn builder() -> builder::GetTaskRequest {
         Default::default()
-    }
-}
-#[doc = "The identifier for this request."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GetTaskRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for GetTaskRequestId {
-    fn from(value: &GetTaskRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for GetTaskRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for GetTaskRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for GetTaskRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for GetTaskRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for GetTaskRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for GetTaskRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `tasks/get` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `tasks/get` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GetTaskResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    GetTaskSuccessResponse(GetTaskSuccessResponse),
-}
-impl ::std::convert::From<&Self> for GetTaskResponse {
-    fn from(value: &GetTaskResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for GetTaskResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<GetTaskSuccessResponse> for GetTaskResponse {
-    fn from(value: GetTaskSuccessResponse) -> Self {
-        Self::GetTaskSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `tasks/get` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `tasks/get` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, containing the requested Task object.\","]
-#[doc = "      \"$ref\": \"#/definitions/Task\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct GetTaskSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: GetTaskSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, containing the requested Task object."]
-    pub result: Task,
-}
-impl ::std::convert::From<&GetTaskSuccessResponse> for GetTaskSuccessResponse {
-    fn from(value: &GetTaskSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl GetTaskSuccessResponse {
-    pub fn builder() -> builder::GetTaskSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum GetTaskSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for GetTaskSuccessResponseId {
-    fn from(value: &GetTaskSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for GetTaskSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
     }
 }
 #[doc = "Defines a security scheme using HTTP authentication."]
@@ -2829,15 +1305,15 @@ impl ::std::convert::From<i64> for GetTaskSuccessResponseId {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"HTTP Auth Security Scheme\","]
 #[doc = "  \"description\": \"Defines a security scheme using HTTP authentication.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"scheme\","]
-#[doc = "    \"type\""]
+#[doc = "    \"scheme\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"bearerFormat\": {"]
-#[doc = "      \"description\": \"A hint to the client to identify how the bearer token is formatted (e.g., \\\"JWT\\\").\\nThis is primarily for documentation purposes.\","]
+#[doc = "      \"description\": \"A hint to the client to identify how the bearer token is formatted (e.g., \\\"JWT\\\").\\n This is primarily for documentation purposes.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"description\": {"]
@@ -2845,21 +1321,19 @@ impl ::std::convert::From<i64> for GetTaskSuccessResponseId {
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"scheme\": {"]
-#[doc = "      \"description\": \"The name of the HTTP Authentication scheme to be used in the Authorization header,\\nas defined in RFC7235 (e.g., \\\"Bearer\\\").\\nThis value should be registered in the IANA Authentication Scheme registry.\","]
+#[doc = "      \"description\": \"The name of the HTTP Authentication scheme to be used in the Authorization header,\\n as defined in RFC7235 (e.g., \\\"Bearer\\\").\\n This value should be registered in the IANA Authentication Scheme registry.\","]
 #[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"type\": {"]
-#[doc = "      \"description\": \"The type of the security scheme. Must be 'http'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"http\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct HttpAuthSecurityScheme {
-    #[doc = "A hint to the client to identify how the bearer token is formatted (e.g., \"JWT\").\nThis is primarily for documentation purposes."]
+    #[doc = "A hint to the client to identify how the bearer token is formatted (e.g., \"JWT\").\n This is primarily for documentation purposes."]
     #[serde(
         rename = "bearerFormat",
         default,
@@ -2869,16 +1343,8 @@ pub struct HttpAuthSecurityScheme {
     #[doc = "An optional description for the security scheme."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[doc = "The name of the HTTP Authentication scheme to be used in the Authorization header,\nas defined in RFC7235 (e.g., \"Bearer\").\nThis value should be registered in the IANA Authentication Scheme registry."]
+    #[doc = "The name of the HTTP Authentication scheme to be used in the Authorization header,\n as defined in RFC7235 (e.g., \"Bearer\").\n This value should be registered in the IANA Authentication Scheme registry."]
     pub scheme: ::std::string::String,
-    #[doc = "The type of the security scheme. Must be 'http'."]
-    #[serde(rename = "type")]
-    pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&HttpAuthSecurityScheme> for HttpAuthSecurityScheme {
-    fn from(value: &HttpAuthSecurityScheme) -> Self {
-        value.clone()
-    }
 }
 impl HttpAuthSecurityScheme {
     pub fn builder() -> builder::HttpAuthSecurityScheme {
@@ -2891,6 +1357,7 @@ impl HttpAuthSecurityScheme {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"ImplicitO Auth Flow\","]
 #[doc = "  \"description\": \"Defines configuration details for the OAuth 2.0 Implicit flow.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
@@ -2899,1414 +1366,431 @@ impl HttpAuthSecurityScheme {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"authorizationUrl\": {"]
-#[doc = "      \"description\": \"The authorization URL to be used for this flow. This MUST be a URL.\","]
+#[doc = "      \"description\": \"The authorization URL to be used for this flow.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"refreshUrl\": {"]
-#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens. This MUST be a URL.\","]
+#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"scopes\": {"]
-#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme. A map between the scope\\nname and a short description for it.\","]
+#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme.\","]
 #[doc = "      \"type\": \"object\","]
 #[doc = "      \"additionalProperties\": {"]
 #[doc = "        \"type\": \"string\""]
+#[doc = "      },"]
+#[doc = "      \"propertyNames\": {"]
+#[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ImplicitOAuthFlow {
-    #[doc = "The authorization URL to be used for this flow. This MUST be a URL."]
+    #[doc = "The authorization URL to be used for this flow."]
     #[serde(rename = "authorizationUrl")]
     pub authorization_url: ::std::string::String,
-    #[doc = "The URL to be used for obtaining refresh tokens. This MUST be a URL."]
+    #[doc = "The URL to be used for obtaining refresh tokens."]
     #[serde(
         rename = "refreshUrl",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub refresh_url: ::std::option::Option<::std::string::String>,
-    #[doc = "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it."]
+    #[doc = "The available scopes for the OAuth2 security scheme."]
     pub scopes: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
-}
-impl ::std::convert::From<&ImplicitOAuthFlow> for ImplicitOAuthFlow {
-    fn from(value: &ImplicitOAuthFlow) -> Self {
-        value.clone()
-    }
 }
 impl ImplicitOAuthFlow {
     pub fn builder() -> builder::ImplicitOAuthFlow {
         Default::default()
     }
 }
-#[doc = "An error indicating an internal error on the server."]
+#[doc = "`ListTaskPushNotificationConfigRequest`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"An error indicating an internal error on the server.\","]
+#[doc = "  \"title\": \"List Task Push Notification Config Request\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
+#[doc = "    \"pageSize\","]
+#[doc = "    \"pageToken\","]
+#[doc = "    \"parent\","]
+#[doc = "    \"tenant\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for an internal server error.\","]
+#[doc = "    \"pageSize\": {"]
+#[doc = "      \"description\": \"The maximum number of configurations to return.\","]
 #[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32603"]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
 #[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Internal error\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct InternalError {
-    #[doc = "The error code for an internal server error."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&InternalError> for InternalError {
-    fn from(value: &InternalError) -> Self {
-        value.clone()
-    }
-}
-impl InternalError {
-    pub fn builder() -> builder::InternalError {
-        Default::default()
-    }
-}
-#[doc = "An A2A-specific error indicating that the agent returned a response that\ndoes not conform to the specification for the current method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An A2A-specific error indicating that the agent returned a response that\\ndoes not conform to the specification for the current method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for an invalid agent response.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32006"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Invalid agent response\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct InvalidAgentResponseError {
-    #[doc = "The error code for an invalid agent response."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&InvalidAgentResponseError> for InvalidAgentResponseError {
-    fn from(value: &InvalidAgentResponseError) -> Self {
-        value.clone()
-    }
-}
-impl InvalidAgentResponseError {
-    pub fn builder() -> builder::InvalidAgentResponseError {
-        Default::default()
-    }
-}
-#[doc = "An error indicating that the method parameters are invalid."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An error indicating that the method parameters are invalid.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for an invalid parameters error.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32602"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Invalid parameters\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct InvalidParamsError {
-    #[doc = "The error code for an invalid parameters error."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&InvalidParamsError> for InvalidParamsError {
-    fn from(value: &InvalidParamsError) -> Self {
-        value.clone()
-    }
-}
-impl InvalidParamsError {
-    pub fn builder() -> builder::InvalidParamsError {
-        Default::default()
-    }
-}
-#[doc = "An error indicating that the JSON sent is not a valid Request object."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An error indicating that the JSON sent is not a valid Request object.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for an invalid request.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32600"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Request payload validation error\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct InvalidRequestError {
-    #[doc = "The error code for an invalid request."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&InvalidRequestError> for InvalidRequestError {
-    fn from(value: &InvalidRequestError) -> Self {
-        value.clone()
-    }
-}
-impl InvalidRequestError {
-    pub fn builder() -> builder::InvalidRequestError {
-        Default::default()
-    }
-}
-#[doc = "An error indicating that the server received invalid JSON."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An error indicating that the server received invalid JSON.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for a JSON parse error.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32700"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Invalid JSON payload\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonParseError {
-    #[doc = "The error code for a JSON parse error."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&JsonParseError> for JsonParseError {
-    fn from(value: &JsonParseError) -> Self {
-        value.clone()
-    }
-}
-impl JsonParseError {
-    pub fn builder() -> builder::JsonParseError {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC 2.0 Error object, included in an error response."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC 2.0 Error object, included in an error response.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"A number that indicates the error type that occurred.\","]
-#[doc = "      \"type\": \"integer\""]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"A string providing a short description of the error.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcError {
-    #[doc = "A number that indicates the error type that occurred."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "A string providing a short description of the error."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&JsonrpcError> for JsonrpcError {
-    fn from(value: &JsonrpcError) -> Self {
-        value.clone()
-    }
-}
-impl JsonrpcError {
-    pub fn builder() -> builder::JsonrpcError {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC 2.0 Error Response object."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC 2.0 Error Response object.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"error\","]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"error\": {"]
-#[doc = "      \"description\": \"An object describing the error that occurred.\","]
-#[doc = "      \"anyOf\": ["]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/JSONRPCError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/JSONParseError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/InvalidRequestError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/MethodNotFoundError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/InvalidParamsError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/InternalError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/TaskNotFoundError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/TaskNotCancelableError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/PushNotificationNotSupportedError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/UnsupportedOperationError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/ContentTypeNotSupportedError\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/InvalidAgentResponseError\""]
-#[doc = "        }"]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcErrorResponse {
-    #[doc = "An object describing the error that occurred."]
-    pub error: JsonrpcErrorResponseError,
-    #[doc = "The identifier established by the client."]
-    pub id: JsonrpcErrorResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-}
-impl ::std::convert::From<&JsonrpcErrorResponse> for JsonrpcErrorResponse {
-    fn from(value: &JsonrpcErrorResponse) -> Self {
-        value.clone()
-    }
-}
-impl JsonrpcErrorResponse {
-    pub fn builder() -> builder::JsonrpcErrorResponse {
-        Default::default()
-    }
-}
-#[doc = "An object describing the error that occurred."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An object describing the error that occurred.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONParseError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InvalidRequestError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/MethodNotFoundError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InvalidParamsError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InternalError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskNotFoundError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskNotCancelableError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/PushNotificationNotSupportedError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/UnsupportedOperationError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/ContentTypeNotSupportedError\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/InvalidAgentResponseError\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcErrorResponseError {
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_0: ::std::option::Option<JsonrpcError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_1: ::std::option::Option<JsonParseError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_2: ::std::option::Option<InvalidRequestError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_3: ::std::option::Option<MethodNotFoundError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_4: ::std::option::Option<InvalidParamsError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_5: ::std::option::Option<InternalError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_6: ::std::option::Option<TaskNotFoundError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_7: ::std::option::Option<TaskNotCancelableError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_8: ::std::option::Option<PushNotificationNotSupportedError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_9: ::std::option::Option<UnsupportedOperationError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_10: ::std::option::Option<ContentTypeNotSupportedError>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_11: ::std::option::Option<InvalidAgentResponseError>,
-}
-impl ::std::convert::From<&JsonrpcErrorResponseError> for JsonrpcErrorResponseError {
-    fn from(value: &JsonrpcErrorResponseError) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for JsonrpcErrorResponseError {
-    fn default() -> Self {
-        Self {
-            subtype_0: Default::default(),
-            subtype_1: Default::default(),
-            subtype_2: Default::default(),
-            subtype_3: Default::default(),
-            subtype_4: Default::default(),
-            subtype_5: Default::default(),
-            subtype_6: Default::default(),
-            subtype_7: Default::default(),
-            subtype_8: Default::default(),
-            subtype_9: Default::default(),
-            subtype_10: Default::default(),
-            subtype_11: Default::default(),
-        }
-    }
-}
-impl JsonrpcErrorResponseError {
-    pub fn builder() -> builder::JsonrpcErrorResponseError {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum JsonrpcErrorResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for JsonrpcErrorResponseId {
-    fn from(value: &JsonrpcErrorResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for JsonrpcErrorResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Defines the base structure for any JSON-RPC 2.0 request, response, or notification."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines the base structure for any JSON-RPC 2.0 request, response, or notification.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"jsonrpc\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"A unique identifier established by the client. It must be a String, a Number, or null.\\nThe server must reply with the same value in the response. This property is omitted for notifications.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcMessage {
-    #[doc = "A unique identifier established by the client. It must be a String, a Number, or null.\nThe server must reply with the same value in the response. This property is omitted for notifications."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub id: ::std::option::Option<JsonrpcMessageId>,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-}
-impl ::std::convert::From<&JsonrpcMessage> for JsonrpcMessage {
-    fn from(value: &JsonrpcMessage) -> Self {
-        value.clone()
-    }
-}
-impl JsonrpcMessage {
-    pub fn builder() -> builder::JsonrpcMessage {
-        Default::default()
-    }
-}
-#[doc = "A unique identifier established by the client. It must be a String, a Number, or null.\nThe server must reply with the same value in the response. This property is omitted for notifications."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"A unique identifier established by the client. It must be a String, a Number, or null.\\nThe server must reply with the same value in the response. This property is omitted for notifications.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum JsonrpcMessageId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for JsonrpcMessageId {
-    fn from(value: &JsonrpcMessageId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for JsonrpcMessageId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC 2.0 Request object."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC 2.0 Request object.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"A unique identifier established by the client. It must be a String, a Number, or null.\\nThe server must reply with the same value in the response. This property is omitted for notifications.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"A string containing the name of the method to be invoked.\","]
+#[doc = "    \"pageToken\": {"]
+#[doc = "      \"description\": \"A page token received from a previous ListTaskPushNotificationConfigRequest call.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"A structured value holding the parameter values to be used during the method invocation.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcRequest {
-    #[doc = "A unique identifier established by the client. It must be a String, a Number, or null.\nThe server must reply with the same value in the response. This property is omitted for notifications."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub id: ::std::option::Option<JsonrpcRequestId>,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "A string containing the name of the method to be invoked."]
-    pub method: ::std::string::String,
-    #[doc = "A structured value holding the parameter values to be used during the method invocation."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub params: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&JsonrpcRequest> for JsonrpcRequest {
-    fn from(value: &JsonrpcRequest) -> Self {
-        value.clone()
-    }
-}
-impl JsonrpcRequest {
-    pub fn builder() -> builder::JsonrpcRequest {
-        Default::default()
-    }
-}
-#[doc = "A unique identifier established by the client. It must be a String, a Number, or null.\nThe server must reply with the same value in the response. This property is omitted for notifications."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"A unique identifier established by the client. It must be a String, a Number, or null.\\nThe server must reply with the same value in the response. This property is omitted for notifications.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum JsonrpcRequestId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for JsonrpcRequestId {
-    fn from(value: &JsonrpcRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for JsonrpcRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "A discriminated union representing all possible JSON-RPC 2.0 responses\nfor the A2A specification methods."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"A discriminated union representing all possible JSON-RPC 2.0 responses\\nfor the A2A specification methods.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SendMessageSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SendStreamingMessageSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/CancelTaskSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SetTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/GetTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/ListTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/DeleteTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcResponse {
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_0: ::std::option::Option<JsonrpcErrorResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_1: ::std::option::Option<SendMessageSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_2: ::std::option::Option<SendStreamingMessageSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_3: ::std::option::Option<GetTaskSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_4: ::std::option::Option<CancelTaskSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_5: ::std::option::Option<SetTaskPushNotificationConfigSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_6: ::std::option::Option<GetTaskPushNotificationConfigSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_7: ::std::option::Option<ListTaskPushNotificationConfigSuccessResponse>,
-    #[serde(
-        flatten,
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub subtype_8: ::std::option::Option<DeleteTaskPushNotificationConfigSuccessResponse>,
-}
-impl ::std::convert::From<&JsonrpcResponse> for JsonrpcResponse {
-    fn from(value: &JsonrpcResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for JsonrpcResponse {
-    fn default() -> Self {
-        Self {
-            subtype_0: Default::default(),
-            subtype_1: Default::default(),
-            subtype_2: Default::default(),
-            subtype_3: Default::default(),
-            subtype_4: Default::default(),
-            subtype_5: Default::default(),
-            subtype_6: Default::default(),
-            subtype_7: Default::default(),
-            subtype_8: Default::default(),
-        }
-    }
-}
-impl JsonrpcResponse {
-    pub fn builder() -> builder::JsonrpcResponse {
-        Default::default()
-    }
-}
-#[doc = "Represents a successful JSON-RPC 2.0 Response object."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC 2.0 Response object.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The value of this member is determined by the method invoked on the Server.\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct JsonrpcSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: JsonrpcSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The value of this member is determined by the method invoked on the Server."]
-    pub result: ::serde_json::Value,
-}
-impl ::std::convert::From<&JsonrpcSuccessResponse> for JsonrpcSuccessResponse {
-    fn from(value: &JsonrpcSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl JsonrpcSuccessResponse {
-    pub fn builder() -> builder::JsonrpcSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum JsonrpcSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for JsonrpcSuccessResponseId {
-    fn from(value: &JsonrpcSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for JsonrpcSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Defines parameters for listing all push notification configurations associated with a task."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines parameters for listing all push notification configurations associated with a task.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The unique identifier of the task.\","]
+#[doc = "    \"parent\": {"]
+#[doc = "      \"description\": \"The parent task resource.\\n Format: tasks/{task_id}\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with the request.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct ListTaskPushNotificationConfigParams {
-    #[doc = "The unique identifier of the task."]
-    pub id: ::std::string::String,
-    #[doc = "Optional metadata associated with the request."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&ListTaskPushNotificationConfigParams>
-    for ListTaskPushNotificationConfigParams
-{
-    fn from(value: &ListTaskPushNotificationConfigParams) -> Self {
-        value.clone()
-    }
-}
-impl ListTaskPushNotificationConfigParams {
-    pub fn builder() -> builder::ListTaskPushNotificationConfigParams {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/list` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/pushNotificationConfig/list` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/pushNotificationConfig/list'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/pushNotificationConfig/list\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters identifying the task whose configurations are to be listed.\","]
-#[doc = "      \"$ref\": \"#/definitions/ListTaskPushNotificationConfigParams\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ListTaskPushNotificationConfigRequest {
-    #[doc = "The identifier for this request."]
-    pub id: ListTaskPushNotificationConfigRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/pushNotificationConfig/list'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters identifying the task whose configurations are to be listed."]
-    pub params: ListTaskPushNotificationConfigParams,
-}
-impl ::std::convert::From<&ListTaskPushNotificationConfigRequest>
-    for ListTaskPushNotificationConfigRequest
-{
-    fn from(value: &ListTaskPushNotificationConfigRequest) -> Self {
-        value.clone()
-    }
+    #[doc = "The maximum number of configurations to return."]
+    #[serde(rename = "pageSize")]
+    pub page_size: i32,
+    #[doc = "A page token received from a previous ListTaskPushNotificationConfigRequest call."]
+    #[serde(rename = "pageToken")]
+    pub page_token: ::std::string::String,
+    #[doc = "The parent task resource.\n Format: tasks/{task_id}"]
+    pub parent: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
 impl ListTaskPushNotificationConfigRequest {
     pub fn builder() -> builder::ListTaskPushNotificationConfigRequest {
         Default::default()
     }
 }
-#[doc = "The identifier for this request."]
+#[doc = "Represents a successful response for the `tasks/pushNotificationConfig/list`\n method."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ListTaskPushNotificationConfigRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for ListTaskPushNotificationConfigRequestId {
-    fn from(value: &ListTaskPushNotificationConfigRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for ListTaskPushNotificationConfigRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for ListTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for ListTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for ListTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for ListTaskPushNotificationConfigRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for ListTaskPushNotificationConfigRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/list` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `tasks/pushNotificationConfig/list` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/ListTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ListTaskPushNotificationConfigResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    ListTaskPushNotificationConfigSuccessResponse(ListTaskPushNotificationConfigSuccessResponse),
-}
-impl ::std::convert::From<&Self> for ListTaskPushNotificationConfigResponse {
-    fn from(value: &ListTaskPushNotificationConfigResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for ListTaskPushNotificationConfigResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<ListTaskPushNotificationConfigSuccessResponse>
-    for ListTaskPushNotificationConfigResponse
-{
-    fn from(value: ListTaskPushNotificationConfigSuccessResponse) -> Self {
-        Self::ListTaskPushNotificationConfigSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/list` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/list` method.\","]
+#[doc = "  \"title\": \"List Task Push Notification Config Response\","]
+#[doc = "  \"description\": \"Represents a successful response for the `tasks/pushNotificationConfig/list`\\n method.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
+#[doc = "    \"nextPageToken\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, containing an array of all push notification configurations for the task.\","]
+#[doc = "    \"configs\": {"]
+#[doc = "      \"description\": \"The list of push notification configurations.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/TaskPushNotificationConfig\""]
 #[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"nextPageToken\": {"]
+#[doc = "      \"description\": \"A token, which can be sent as `page_token` to retrieve the next page.\\n If this field is omitted, there are no subsequent pages.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct ListTaskPushNotificationConfigSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: ListTaskPushNotificationConfigSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, containing an array of all push notification configurations for the task."]
-    pub result: ::std::vec::Vec<TaskPushNotificationConfig>,
+#[serde(deny_unknown_fields)]
+pub struct ListTaskPushNotificationConfigResponse {
+    #[doc = "The list of push notification configurations."]
+    #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+    pub configs: ::std::vec::Vec<TaskPushNotificationConfig>,
+    #[doc = "A token, which can be sent as `page_token` to retrieve the next page.\n If this field is omitted, there are no subsequent pages."]
+    #[serde(rename = "nextPageToken")]
+    pub next_page_token: ::std::string::String,
 }
-impl ::std::convert::From<&ListTaskPushNotificationConfigSuccessResponse>
-    for ListTaskPushNotificationConfigSuccessResponse
-{
-    fn from(value: &ListTaskPushNotificationConfigSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl ListTaskPushNotificationConfigSuccessResponse {
-    pub fn builder() -> builder::ListTaskPushNotificationConfigSuccessResponse {
+impl ListTaskPushNotificationConfigResponse {
+    pub fn builder() -> builder::ListTaskPushNotificationConfigResponse {
         Default::default()
     }
 }
-#[doc = "The identifier established by the client."]
+#[doc = "Parameters for listing tasks with optional filtering criteria."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
+#[doc = "  \"title\": \"List Tasks Request\","]
+#[doc = "  \"description\": \"Parameters for listing tasks with optional filtering criteria.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"contextId\","]
+#[doc = "    \"lastUpdatedAfter\","]
+#[doc = "    \"pageToken\","]
+#[doc = "    \"status\","]
+#[doc = "    \"tenant\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"contextId\": {"]
+#[doc = "      \"description\": \"Filter tasks by context ID to get tasks from a specific conversation or session.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"historyLength\": {"]
+#[doc = "      \"description\": \"The maximum number of messages to include in each task's history.\","]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
+#[doc = "    },"]
+#[doc = "    \"includeArtifacts\": {"]
+#[doc = "      \"description\": \"Whether to include artifacts in the returned tasks.\\n Defaults to false to reduce payload size.\","]
+#[doc = "      \"type\": \"boolean\""]
+#[doc = "    },"]
+#[doc = "    \"lastUpdatedAfter\": {"]
+#[doc = "      \"description\": \"Filter tasks updated after this timestamp (milliseconds since epoch).\\n Only tasks with a last updated time greater than or equal to this value will be returned.\","]
+#[doc = "      \"type\": \"integer\""]
+#[doc = "    },"]
+#[doc = "    \"pageSize\": {"]
+#[doc = "      \"description\": \"Maximum number of tasks to return. Must be between 1 and 100.\\n Defaults to 50 if not specified.\","]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
+#[doc = "    },"]
+#[doc = "    \"pageToken\": {"]
+#[doc = "      \"description\": \"Token for pagination. Use the next_page_token from a previous ListTasksResponse.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"status\": {"]
+#[doc = "      \"title\": \"Task State\","]
+#[doc = "      \"description\": \"Filter tasks by their current status state.\","]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"TASK_STATE_UNSPECIFIED\","]
+#[doc = "        \"TASK_STATE_SUBMITTED\","]
+#[doc = "        \"TASK_STATE_WORKING\","]
+#[doc = "        \"TASK_STATE_COMPLETED\","]
+#[doc = "        \"TASK_STATE_FAILED\","]
+#[doc = "        \"TASK_STATE_CANCELLED\","]
+#[doc = "        \"TASK_STATE_INPUT_REQUIRED\","]
+#[doc = "        \"TASK_STATE_REJECTED\","]
+#[doc = "        \"TASK_STATE_AUTH_REQUIRED\""]
+#[doc = "      ]"]
+#[doc = "    },"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ListTaskPushNotificationConfigSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
+#[serde(deny_unknown_fields)]
+pub struct ListTasksRequest {
+    #[doc = "Filter tasks by context ID to get tasks from a specific conversation or session."]
+    #[serde(rename = "contextId")]
+    pub context_id: ::std::string::String,
+    #[doc = "The maximum number of messages to include in each task's history."]
+    #[serde(
+        rename = "historyLength",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub history_length: ::std::option::Option<i32>,
+    #[doc = "Whether to include artifacts in the returned tasks.\n Defaults to false to reduce payload size."]
+    #[serde(
+        rename = "includeArtifacts",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub include_artifacts: ::std::option::Option<bool>,
+    #[doc = "Filter tasks updated after this timestamp (milliseconds since epoch).\n Only tasks with a last updated time greater than or equal to this value will be returned."]
+    #[serde(rename = "lastUpdatedAfter")]
+    pub last_updated_after: i64,
+    #[doc = "Maximum number of tasks to return. Must be between 1 and 100.\n Defaults to 50 if not specified."]
+    #[serde(
+        rename = "pageSize",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub page_size: ::std::option::Option<i32>,
+    #[doc = "Token for pagination. Use the next_page_token from a previous ListTasksResponse."]
+    #[serde(rename = "pageToken")]
+    pub page_token: ::std::string::String,
+    #[doc = "Filter tasks by their current status state."]
+    pub status: TaskState,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
-impl ::std::convert::From<&Self> for ListTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: &ListTaskPushNotificationConfigSuccessResponseId) -> Self {
-        value.clone()
+impl ListTasksRequest {
+    pub fn builder() -> builder::ListTasksRequest {
+        Default::default()
     }
 }
-impl ::std::convert::From<i64> for ListTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a single message in the conversation between a user and an agent."]
+#[doc = "Result object for tasks/list method containing an array of tasks and pagination information."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a single message in the conversation between a user and an agent.\","]
+#[doc = "  \"title\": \"List Tasks Response\","]
+#[doc = "  \"description\": \"Result object for tasks/list method containing an array of tasks and pagination information.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"kind\","]
+#[doc = "    \"nextPageToken\","]
+#[doc = "    \"pageSize\","]
+#[doc = "    \"tasks\","]
+#[doc = "    \"totalSize\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"nextPageToken\": {"]
+#[doc = "      \"description\": \"Token for retrieving the next page. Empty string if no more results.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"pageSize\": {"]
+#[doc = "      \"description\": \"The size of page requested.\","]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
+#[doc = "    },"]
+#[doc = "    \"tasks\": {"]
+#[doc = "      \"description\": \"Array of tasks matching the specified criteria.\","]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/definitions/Task\""]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"totalSize\": {"]
+#[doc = "      \"description\": \"Total number of tasks available (before pagination).\","]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ListTasksResponse {
+    #[doc = "Token for retrieving the next page. Empty string if no more results."]
+    #[serde(rename = "nextPageToken")]
+    pub next_page_token: ::std::string::String,
+    #[doc = "The size of page requested."]
+    #[serde(rename = "pageSize")]
+    pub page_size: i32,
+    #[doc = "Array of tasks matching the specified criteria."]
+    pub tasks: ::std::vec::Vec<Task>,
+    #[doc = "Total number of tasks available (before pagination)."]
+    #[serde(rename = "totalSize")]
+    pub total_size: i32,
+}
+impl ListTasksResponse {
+    pub fn builder() -> builder::ListTasksResponse {
+        Default::default()
+    }
+}
+#[doc = "Message is one unit of communication between client and server. It is\n associated with a context and optionally a task. Since the server is\n responsible for the context definition, it must always provide a context_id\n in its messages. The client can optionally provide the context_id if it\n knows the context to associate the message to. Similarly for task_id,\n except the server decides if a task is created and whether to include the\n task_id."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Message\","]
+#[doc = "  \"description\": \"Message is one unit of communication between client and server. It is\\n associated with a context and optionally a task. Since the server is\\n responsible for the context definition, it must always provide a context_id\\n in its messages. The client can optionally provide the context_id if it\\n knows the context to associate the message to. Similarly for task_id,\\n except the server decides if a task is created and whether to include the\\n task_id.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
 #[doc = "    \"messageId\","]
 #[doc = "    \"parts\","]
 #[doc = "    \"role\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"contextId\": {"]
-#[doc = "      \"description\": \"The context identifier for this message, used to group related interactions.\","]
+#[doc = "      \"description\": \"The context id of the message. This is optional and if set, the message\\n will be associated with the given context.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"extensions\": {"]
-#[doc = "      \"description\": \"The URIs of extensions that are relevant to this message.\","]
+#[doc = "      \"description\": \"The URIs of extensions that are present or contributed to this Message.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this object, used as a discriminator. Always 'message' for a Message.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"message\""]
-#[doc = "    },"]
 #[doc = "    \"messageId\": {"]
-#[doc = "      \"description\": \"A unique identifier for the message, typically a UUID, generated by the sender.\","]
+#[doc = "      \"description\": \"The unique identifier (e.g. UUID) of the message. This is required and\\n created by the message creator.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata for extensions. The key is an extension-specific identifier.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"description\": \"protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\\n Any optional metadata to provide along with the message.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"parts\": {"]
-#[doc = "      \"description\": \"An array of content parts that form the message body. A message can be\\ncomposed of multiple parts of different types (e.g., text and files).\","]
+#[doc = "      \"description\": \"protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\\n Parts is the container of the message content.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/Part\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"referenceTaskIds\": {"]
-#[doc = "      \"description\": \"A list of other task IDs that this message references for additional context.\","]
+#[doc = "      \"description\": \"A list of task IDs that this message references for additional context.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"role\": {"]
-#[doc = "      \"description\": \"Identifies the sender of the message. `user` for the client, `agent` for the service.\","]
+#[doc = "      \"title\": \"Role\","]
+#[doc = "      \"description\": \"Identifies the sender of the message.\","]
 #[doc = "      \"type\": \"string\","]
 #[doc = "      \"enum\": ["]
-#[doc = "        \"agent\","]
-#[doc = "        \"user\""]
+#[doc = "        \"ROLE_UNSPECIFIED\","]
+#[doc = "        \"ROLE_USER\","]
+#[doc = "        \"ROLE_AGENT\""]
 #[doc = "      ]"]
 #[doc = "    },"]
 #[doc = "    \"taskId\": {"]
-#[doc = "      \"description\": \"The identifier of the task this message is part of. Can be omitted for the first message of a new task.\","]
+#[doc = "      \"description\": \"The task id of the message. This is optional and if set, the message\\n will be associated with the given task.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Message {
-    #[doc = "The context identifier for this message, used to group related interactions."]
+    #[doc = "The context id of the message. This is optional and if set, the message\n will be associated with the given context."]
     #[serde(
         rename = "contextId",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub context_id: ::std::option::Option<::std::string::String>,
-    #[doc = "The URIs of extensions that are relevant to this message."]
+    #[doc = "The URIs of extensions that are present or contributed to this Message."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub extensions: ::std::vec::Vec<::std::string::String>,
-    #[doc = "The type of this object, used as a discriminator. Always 'message' for a Message."]
-    pub kind: ::std::string::String,
-    #[doc = "A unique identifier for the message, typically a UUID, generated by the sender."]
+    #[doc = "The unique identifier (e.g. UUID) of the message. This is required and\n created by the message creator."]
     #[serde(rename = "messageId")]
     pub message_id: ::std::string::String,
-    #[doc = "Optional metadata for extensions. The key is an extension-specific identifier."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "An array of content parts that form the message body. A message can be\ncomposed of multiple parts of different types (e.g., text and files)."]
+    #[doc = "protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\n Any optional metadata to provide along with the message."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
+    #[doc = "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n Parts is the container of the message content."]
     pub parts: ::std::vec::Vec<Part>,
-    #[doc = "A list of other task IDs that this message references for additional context."]
+    #[doc = "A list of task IDs that this message references for additional context."]
     #[serde(
         rename = "referenceTaskIds",
         default,
         skip_serializing_if = "::std::vec::Vec::is_empty"
     )]
     pub reference_task_ids: ::std::vec::Vec<::std::string::String>,
-    #[doc = "Identifies the sender of the message. `user` for the client, `agent` for the service."]
-    pub role: MessageRole,
-    #[doc = "The identifier of the task this message is part of. Can be omitted for the first message of a new task."]
+    #[doc = "Identifies the sender of the message."]
+    pub role: Role,
+    #[doc = "The task id of the message. This is optional and if set, the message\n will be associated with the given task."]
     #[serde(
         rename = "taskId",
         default,
@@ -4314,270 +1798,42 @@ pub struct Message {
     )]
     pub task_id: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&Message> for Message {
-    fn from(value: &Message) -> Self {
-        value.clone()
-    }
-}
 impl Message {
     pub fn builder() -> builder::Message {
         Default::default()
     }
 }
-#[doc = "Identifies the sender of the message. `user` for the client, `agent` for the service."]
+#[doc = "Defines a security scheme using mTLS authentication."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Identifies the sender of the message. `user` for the client, `agent` for the service.\","]
-#[doc = "  \"type\": \"string\","]
-#[doc = "  \"enum\": ["]
-#[doc = "    \"agent\","]
-#[doc = "    \"user\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(
-    :: serde :: Deserialize,
-    :: serde :: Serialize,
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-)]
-pub enum MessageRole {
-    #[serde(rename = "agent")]
-    Agent,
-    #[serde(rename = "user")]
-    User,
-}
-impl ::std::convert::From<&Self> for MessageRole {
-    fn from(value: &MessageRole) -> Self {
-        value.clone()
-    }
-}
-impl ::std::fmt::Display for MessageRole {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match *self {
-            Self::Agent => write!(f, "agent"),
-            Self::User => write!(f, "user"),
-        }
-    }
-}
-impl ::std::str::FromStr for MessageRole {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        match value {
-            "agent" => Ok(Self::Agent),
-            "user" => Ok(Self::User),
-            _ => Err("invalid value".into()),
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for MessageRole {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for MessageRole {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for MessageRole {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-#[doc = "Defines configuration options for a `message/send` or `message/stream` request."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines configuration options for a `message/send` or `message/stream` request.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"acceptedOutputModes\": {"]
-#[doc = "      \"description\": \"A list of output MIME types the client is prepared to accept in the response.\","]
-#[doc = "      \"type\": \"array\","]
-#[doc = "      \"items\": {"]
-#[doc = "        \"type\": \"string\""]
-#[doc = "      }"]
-#[doc = "    },"]
-#[doc = "    \"blocking\": {"]
-#[doc = "      \"description\": \"If true, the client will wait for the task to complete. The server may reject this if the task is long-running.\","]
-#[doc = "      \"type\": \"boolean\""]
-#[doc = "    },"]
-#[doc = "    \"historyLength\": {"]
-#[doc = "      \"description\": \"The number of most recent messages from the task's history to retrieve in the response.\","]
-#[doc = "      \"type\": \"integer\""]
-#[doc = "    },"]
-#[doc = "    \"pushNotificationConfig\": {"]
-#[doc = "      \"description\": \"Configuration for the agent to send push notifications for updates after the initial response.\","]
-#[doc = "      \"$ref\": \"#/definitions/PushNotificationConfig\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct MessageSendConfiguration {
-    #[doc = "A list of output MIME types the client is prepared to accept in the response."]
-    #[serde(
-        rename = "acceptedOutputModes",
-        default,
-        skip_serializing_if = "::std::vec::Vec::is_empty"
-    )]
-    pub accepted_output_modes: ::std::vec::Vec<::std::string::String>,
-    #[doc = "If true, the client will wait for the task to complete. The server may reject this if the task is long-running."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub blocking: ::std::option::Option<bool>,
-    #[doc = "The number of most recent messages from the task's history to retrieve in the response."]
-    #[serde(
-        rename = "historyLength",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub history_length: ::std::option::Option<i64>,
-    #[doc = "Configuration for the agent to send push notifications for updates after the initial response."]
-    #[serde(
-        rename = "pushNotificationConfig",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub push_notification_config: ::std::option::Option<PushNotificationConfig>,
-}
-impl ::std::convert::From<&MessageSendConfiguration> for MessageSendConfiguration {
-    fn from(value: &MessageSendConfiguration) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for MessageSendConfiguration {
-    fn default() -> Self {
-        Self {
-            accepted_output_modes: Default::default(),
-            blocking: Default::default(),
-            history_length: Default::default(),
-            push_notification_config: Default::default(),
-        }
-    }
-}
-impl MessageSendConfiguration {
-    pub fn builder() -> builder::MessageSendConfiguration {
-        Default::default()
-    }
-}
-#[doc = "Defines the parameters for a request to send a message to an agent. This can be used\nto create a new task, continue an existing one, or restart a task."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines the parameters for a request to send a message to an agent. This can be used\\nto create a new task, continue an existing one, or restart a task.\","]
+#[doc = "  \"title\": \"Mutual Tls Security Scheme\","]
+#[doc = "  \"description\": \"Defines a security scheme using mTLS authentication.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"message\""]
+#[doc = "    \"description\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"configuration\": {"]
-#[doc = "      \"description\": \"Optional configuration for the send request.\","]
-#[doc = "      \"$ref\": \"#/definitions/MessageSendConfiguration\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The message object being sent to the agent.\","]
-#[doc = "      \"$ref\": \"#/definitions/Message\""]
-#[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata for extensions.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct MessageSendParams {
-    #[doc = "Optional configuration for the send request."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub configuration: ::std::option::Option<MessageSendConfiguration>,
-    #[doc = "The message object being sent to the agent."]
-    pub message: Message,
-    #[doc = "Optional metadata for extensions."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&MessageSendParams> for MessageSendParams {
-    fn from(value: &MessageSendParams) -> Self {
-        value.clone()
-    }
-}
-impl MessageSendParams {
-    pub fn builder() -> builder::MessageSendParams {
-        Default::default()
-    }
-}
-#[doc = "An error indicating that the requested method does not exist or is not available."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An error indicating that the requested method does not exist or is not available.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for a method not found error.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32601"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Method not found\","]
+#[doc = "    \"description\": {"]
+#[doc = "      \"description\": \"An optional description for the security scheme.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct MethodNotFoundError {
-    #[doc = "The error code for a method not found error."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
+#[serde(deny_unknown_fields)]
+pub struct MutualTlsSecurityScheme {
+    #[doc = "An optional description for the security scheme."]
+    pub description: ::std::string::String,
 }
-impl ::std::convert::From<&MethodNotFoundError> for MethodNotFoundError {
-    fn from(value: &MethodNotFoundError) -> Self {
-        value.clone()
-    }
-}
-impl MethodNotFoundError {
-    pub fn builder() -> builder::MethodNotFoundError {
+impl MutualTlsSecurityScheme {
+    pub fn builder() -> builder::MutualTlsSecurityScheme {
         Default::default()
     }
 }
@@ -4587,11 +1843,11 @@ impl MethodNotFoundError {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"O Auth2 Security Scheme\","]
 #[doc = "  \"description\": \"Defines a security scheme using OAuth 2.0.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"flows\","]
-#[doc = "    \"type\""]
+#[doc = "    \"flows\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"description\": {"]
@@ -4602,30 +1858,31 @@ impl MethodNotFoundError {
 #[doc = "      \"description\": \"An object containing configuration information for the supported OAuth 2.0 flows.\","]
 #[doc = "      \"$ref\": \"#/definitions/OAuthFlows\""]
 #[doc = "    },"]
-#[doc = "    \"type\": {"]
-#[doc = "      \"description\": \"The type of the security scheme. Must be 'oauth2'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"oauth2\""]
+#[doc = "    \"oauth2MetadataUrl\": {"]
+#[doc = "      \"description\": \"URL to the oauth2 authorization server metadata\\n RFC8414 (https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct OAuth2SecurityScheme {
     #[doc = "An optional description for the security scheme."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
     #[doc = "An object containing configuration information for the supported OAuth 2.0 flows."]
     pub flows: OAuthFlows,
-    #[doc = "The type of the security scheme. Must be 'oauth2'."]
-    #[serde(rename = "type")]
-    pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&OAuth2SecurityScheme> for OAuth2SecurityScheme {
-    fn from(value: &OAuth2SecurityScheme) -> Self {
-        value.clone()
-    }
+    #[doc = "URL to the oauth2 authorization server metadata\n RFC8414 (https://datatracker.ietf.org/doc/html/rfc8414). TLS is required."]
+    #[serde(
+        rename = "oauth2MetadataUrl",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub oauth2_metadata_url: ::std::option::Option<::std::string::String>,
 }
 impl OAuth2SecurityScheme {
     pub fn builder() -> builder::OAuth2SecurityScheme {
@@ -4638,15 +1895,16 @@ impl OAuth2SecurityScheme {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"O Auth Flows\","]
 #[doc = "  \"description\": \"Defines the configuration for the supported OAuth 2.0 flows.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"authorizationCode\": {"]
-#[doc = "      \"description\": \"Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0.\","]
+#[doc = "      \"description\": \"Configuration for the OAuth Authorization Code flow.\","]
 #[doc = "      \"$ref\": \"#/definitions/AuthorizationCodeOAuthFlow\""]
 #[doc = "    },"]
 #[doc = "    \"clientCredentials\": {"]
-#[doc = "      \"description\": \"Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0.\","]
+#[doc = "      \"description\": \"Configuration for the OAuth Client Credentials flow.\","]
 #[doc = "      \"$ref\": \"#/definitions/ClientCredentialsOAuthFlow\""]
 #[doc = "    },"]
 #[doc = "    \"implicit\": {"]
@@ -4657,20 +1915,23 @@ impl OAuth2SecurityScheme {
 #[doc = "      \"description\": \"Configuration for the OAuth Resource Owner Password flow.\","]
 #[doc = "      \"$ref\": \"#/definitions/PasswordOAuthFlow\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct OAuthFlows {
-    #[doc = "Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0."]
+    #[doc = "Configuration for the OAuth Authorization Code flow."]
     #[serde(
         rename = "authorizationCode",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub authorization_code: ::std::option::Option<AuthorizationCodeOAuthFlow>,
-    #[doc = "Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0."]
+    #[doc = "Configuration for the OAuth Client Credentials flow."]
     #[serde(
         rename = "clientCredentials",
         default,
@@ -4683,11 +1944,6 @@ pub struct OAuthFlows {
     #[doc = "Configuration for the OAuth Resource Owner Password flow."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub password: ::std::option::Option<PasswordOAuthFlow>,
-}
-impl ::std::convert::From<&OAuthFlows> for OAuthFlows {
-    fn from(value: &OAuthFlows) -> Self {
-        value.clone()
-    }
 }
 impl ::std::default::Default for OAuthFlows {
     fn default() -> Self {
@@ -4710,11 +1966,11 @@ impl OAuthFlows {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"Open Id Connect Security Scheme\","]
 #[doc = "  \"description\": \"Defines a security scheme using OpenID Connect.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"openIdConnectUrl\","]
-#[doc = "    \"type\""]
+#[doc = "    \"openIdConnectUrl\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"description\": {"]
@@ -4722,126 +1978,90 @@ impl OAuthFlows {
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"openIdConnectUrl\": {"]
-#[doc = "      \"description\": \"The OpenID Connect Discovery URL for the OIDC provider's metadata.\","]
+#[doc = "      \"description\": \"The OpenID Connect Discovery URL for the OIDC provider's metadata.\\n See: https://openid.net/specs/openid-connect-discovery-1_0.html\","]
 #[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"type\": {"]
-#[doc = "      \"description\": \"The type of the security scheme. Must be 'openIdConnect'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"openIdConnect\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct OpenIdConnectSecurityScheme {
     #[doc = "An optional description for the security scheme."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
-    #[doc = "The OpenID Connect Discovery URL for the OIDC provider's metadata."]
+    #[doc = "The OpenID Connect Discovery URL for the OIDC provider's metadata.\n See: https://openid.net/specs/openid-connect-discovery-1_0.html"]
     #[serde(rename = "openIdConnectUrl")]
     pub open_id_connect_url: ::std::string::String,
-    #[doc = "The type of the security scheme. Must be 'openIdConnect'."]
-    #[serde(rename = "type")]
-    pub type_: ::std::string::String,
-}
-impl ::std::convert::From<&OpenIdConnectSecurityScheme> for OpenIdConnectSecurityScheme {
-    fn from(value: &OpenIdConnectSecurityScheme) -> Self {
-        value.clone()
-    }
 }
 impl OpenIdConnectSecurityScheme {
     pub fn builder() -> builder::OpenIdConnectSecurityScheme {
         Default::default()
     }
 }
-#[doc = "A discriminated union representing a part of a message or artifact, which can\nbe text, a file, or structured data."]
+#[doc = "Part represents a container for a section of communication content.\n Parts can be purely textual, some sort of file (image, video, etc) or\n a structured data blob (i.e. JSON)."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"A discriminated union representing a part of a message or artifact, which can\\nbe text, a file, or structured data.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TextPart\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/FilePart\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/DataPart\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum Part {
-    TextPart(TextPart),
-    FilePart(FilePart),
-    DataPart(DataPart),
-}
-impl ::std::convert::From<&Self> for Part {
-    fn from(value: &Part) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<TextPart> for Part {
-    fn from(value: TextPart) -> Self {
-        Self::TextPart(value)
-    }
-}
-impl ::std::convert::From<FilePart> for Part {
-    fn from(value: FilePart) -> Self {
-        Self::FilePart(value)
-    }
-}
-impl ::std::convert::From<DataPart> for Part {
-    fn from(value: DataPart) -> Self {
-        Self::DataPart(value)
-    }
-}
-#[doc = "Defines base properties common to all message or artifact parts."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines base properties common to all message or artifact parts.\","]
+#[doc = "  \"title\": \"Part\","]
+#[doc = "  \"description\": \"Part represents a container for a section of communication content.\\n Parts can be purely textual, some sort of file (image, video, etc) or\\n a structured data blob (i.e. JSON).\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"properties\": {"]
+#[doc = "    \"data\": {"]
+#[doc = "      \"description\": \"The structured data content.\","]
+#[doc = "      \"$ref\": \"#/definitions/DataPart\""]
+#[doc = "    },"]
+#[doc = "    \"file\": {"]
+#[doc = "      \"description\": \"The file content, represented as either a URI or as base64-encoded bytes.\","]
+#[doc = "      \"$ref\": \"#/definitions/FilePart\""]
+#[doc = "    },"]
 #[doc = "    \"metadata\": {"]
 #[doc = "      \"description\": \"Optional metadata associated with this part.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
+#[doc = "    },"]
+#[doc = "    \"text\": {"]
+#[doc = "      \"description\": \"The string content of the text part.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct PartBase {
+#[serde(deny_unknown_fields)]
+pub struct Part {
+    #[doc = "The structured data content."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub data: ::std::option::Option<DataPart>,
+    #[doc = "The file content, represented as either a URI or as base64-encoded bytes."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub file: ::std::option::Option<FilePart>,
     #[doc = "Optional metadata associated with this part."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
+    #[doc = "The string content of the text part."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub text: ::std::option::Option<::std::string::String>,
 }
-impl ::std::convert::From<&PartBase> for PartBase {
-    fn from(value: &PartBase) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for PartBase {
+impl ::std::default::Default for Part {
     fn default() -> Self {
         Self {
+            data: Default::default(),
+            file: Default::default(),
             metadata: Default::default(),
+            text: Default::default(),
         }
     }
 }
-impl PartBase {
-    pub fn builder() -> builder::PartBase {
+impl Part {
+    pub fn builder() -> builder::Part {
         Default::default()
     }
 }
@@ -4851,6 +2071,7 @@ impl PartBase {
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
+#[doc = "  \"title\": \"PasswordO Auth Flow\","]
 #[doc = "  \"description\": \"Defines configuration details for the OAuth 2.0 Resource Owner Password flow.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
@@ -4859,1302 +2080,825 @@ impl PartBase {
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"refreshUrl\": {"]
-#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens. This MUST be a URL.\","]
+#[doc = "      \"description\": \"The URL to be used for obtaining refresh tokens.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"scopes\": {"]
-#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme. A map between the scope\\nname and a short description for it.\","]
+#[doc = "      \"description\": \"The available scopes for the OAuth2 security scheme.\","]
 #[doc = "      \"type\": \"object\","]
 #[doc = "      \"additionalProperties\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      },"]
+#[doc = "      \"propertyNames\": {"]
 #[doc = "        \"type\": \"string\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"tokenUrl\": {"]
-#[doc = "      \"description\": \"The token URL to be used for this flow. This MUST be a URL.\","]
+#[doc = "      \"description\": \"The token URL to be used for this flow.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct PasswordOAuthFlow {
-    #[doc = "The URL to be used for obtaining refresh tokens. This MUST be a URL."]
+    #[doc = "The URL to be used for obtaining refresh tokens."]
     #[serde(
         rename = "refreshUrl",
         default,
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub refresh_url: ::std::option::Option<::std::string::String>,
-    #[doc = "The available scopes for the OAuth2 security scheme. A map between the scope\nname and a short description for it."]
+    #[doc = "The available scopes for the OAuth2 security scheme."]
     pub scopes: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
-    #[doc = "The token URL to be used for this flow. This MUST be a URL."]
+    #[doc = "The token URL to be used for this flow."]
     #[serde(rename = "tokenUrl")]
     pub token_url: ::std::string::String,
-}
-impl ::std::convert::From<&PasswordOAuthFlow> for PasswordOAuthFlow {
-    fn from(value: &PasswordOAuthFlow) -> Self {
-        value.clone()
-    }
 }
 impl PasswordOAuthFlow {
     pub fn builder() -> builder::PasswordOAuthFlow {
         Default::default()
     }
 }
-#[doc = "Defines authentication details for a push notification endpoint."]
+#[doc = "Configuration for setting up push notifications for task updates."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Defines authentication details for a push notification endpoint.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"schemes\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"credentials\": {"]
-#[doc = "      \"description\": \"Optional credentials required by the push notification endpoint.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"schemes\": {"]
-#[doc = "      \"description\": \"A list of supported authentication schemes (e.g., 'Basic', 'Bearer').\","]
-#[doc = "      \"type\": \"array\","]
-#[doc = "      \"items\": {"]
-#[doc = "        \"type\": \"string\""]
-#[doc = "      }"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct PushNotificationAuthenticationInfo {
-    #[doc = "Optional credentials required by the push notification endpoint."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub credentials: ::std::option::Option<::std::string::String>,
-    #[doc = "A list of supported authentication schemes (e.g., 'Basic', 'Bearer')."]
-    pub schemes: ::std::vec::Vec<::std::string::String>,
-}
-impl ::std::convert::From<&PushNotificationAuthenticationInfo>
-    for PushNotificationAuthenticationInfo
-{
-    fn from(value: &PushNotificationAuthenticationInfo) -> Self {
-        value.clone()
-    }
-}
-impl PushNotificationAuthenticationInfo {
-    pub fn builder() -> builder::PushNotificationAuthenticationInfo {
-        Default::default()
-    }
-}
-#[doc = "Defines the configuration for setting up push notifications for task updates."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines the configuration for setting up push notifications for task updates.\","]
+#[doc = "  \"title\": \"Push Notification Config\","]
+#[doc = "  \"description\": \"Configuration for setting up push notifications for task updates.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"url\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"authentication\": {"]
-#[doc = "      \"description\": \"Optional authentication details for the agent to use when calling the notification URL.\","]
-#[doc = "      \"$ref\": \"#/definitions/PushNotificationAuthenticationInfo\""]
+#[doc = "      \"description\": \"Information about the authentication to sent with the notification\","]
+#[doc = "      \"$ref\": \"#/definitions/AuthenticationInfo\""]
 #[doc = "    },"]
 #[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"A unique ID for the push notification configuration, created by the server\\nto support multiple notification callbacks.\","]
+#[doc = "      \"description\": \"A unique identifier (e.g. UUID) for this push notification.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"token\": {"]
-#[doc = "      \"description\": \"A unique token for this task or session to validate incoming push notifications.\","]
+#[doc = "      \"description\": \"Token unique for this task/session\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"url\": {"]
-#[doc = "      \"description\": \"The callback URL where the agent should send push notifications.\","]
+#[doc = "      \"description\": \"Url to send the notification too\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct PushNotificationConfig {
-    #[doc = "Optional authentication details for the agent to use when calling the notification URL."]
+    #[doc = "Information about the authentication to sent with the notification"]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub authentication: ::std::option::Option<PushNotificationAuthenticationInfo>,
-    #[doc = "A unique ID for the push notification configuration, created by the server\nto support multiple notification callbacks."]
+    pub authentication: ::std::option::Option<AuthenticationInfo>,
+    #[doc = "A unique identifier (e.g. UUID) for this push notification."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub id: ::std::option::Option<::std::string::String>,
-    #[doc = "A unique token for this task or session to validate incoming push notifications."]
+    #[doc = "Token unique for this task/session"]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub token: ::std::option::Option<::std::string::String>,
-    #[doc = "The callback URL where the agent should send push notifications."]
+    #[doc = "Url to send the notification too"]
     pub url: ::std::string::String,
-}
-impl ::std::convert::From<&PushNotificationConfig> for PushNotificationConfig {
-    fn from(value: &PushNotificationConfig) -> Self {
-        value.clone()
-    }
 }
 impl PushNotificationConfig {
     pub fn builder() -> builder::PushNotificationConfig {
         Default::default()
     }
 }
-#[doc = "An A2A-specific error indicating that the agent does not support push notifications."]
+#[doc = "Identifies the sender of the message."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"An A2A-specific error indicating that the agent does not support push notifications.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for when push notifications are not supported.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32003"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Push Notification is not supported\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct PushNotificationNotSupportedError {
-    #[doc = "The error code for when push notifications are not supported."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&PushNotificationNotSupportedError>
-    for PushNotificationNotSupportedError
-{
-    fn from(value: &PushNotificationNotSupportedError) -> Self {
-        value.clone()
-    }
-}
-impl PushNotificationNotSupportedError {
-    pub fn builder() -> builder::PushNotificationNotSupportedError {
-        Default::default()
-    }
-}
-#[doc = "Defines a security scheme that can be used to secure an agent's endpoints.\nThis is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines a security scheme that can be used to secure an agent's endpoints.\\nThis is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/APIKeySecurityScheme\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/HTTPAuthSecurityScheme\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/OAuth2SecurityScheme\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/OpenIdConnectSecurityScheme\""]
-#[doc = "    }"]
+#[doc = "  \"title\": \"Role\","]
+#[doc = "  \"description\": \"Identifies the sender of the message.\","]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"enum\": ["]
+#[doc = "    \"ROLE_UNSPECIFIED\","]
+#[doc = "    \"ROLE_USER\","]
+#[doc = "    \"ROLE_AGENT\""]
 #[doc = "  ]"]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SecurityScheme {
-    ApiKeySecurityScheme(ApiKeySecurityScheme),
-    HttpAuthSecurityScheme(HttpAuthSecurityScheme),
-    OAuth2SecurityScheme(OAuth2SecurityScheme),
-    OpenIdConnectSecurityScheme(OpenIdConnectSecurityScheme),
+#[derive(
+    :: serde :: Deserialize,
+    :: serde :: Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
+pub enum Role {
+    #[serde(rename = "ROLE_UNSPECIFIED")]
+    RoleUnspecified,
+    #[serde(rename = "ROLE_USER")]
+    RoleUser,
+    #[serde(rename = "ROLE_AGENT")]
+    RoleAgent,
 }
-impl ::std::convert::From<&Self> for SecurityScheme {
-    fn from(value: &SecurityScheme) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<ApiKeySecurityScheme> for SecurityScheme {
-    fn from(value: ApiKeySecurityScheme) -> Self {
-        Self::ApiKeySecurityScheme(value)
-    }
-}
-impl ::std::convert::From<HttpAuthSecurityScheme> for SecurityScheme {
-    fn from(value: HttpAuthSecurityScheme) -> Self {
-        Self::HttpAuthSecurityScheme(value)
-    }
-}
-impl ::std::convert::From<OAuth2SecurityScheme> for SecurityScheme {
-    fn from(value: OAuth2SecurityScheme) -> Self {
-        Self::OAuth2SecurityScheme(value)
-    }
-}
-impl ::std::convert::From<OpenIdConnectSecurityScheme> for SecurityScheme {
-    fn from(value: OpenIdConnectSecurityScheme) -> Self {
-        Self::OpenIdConnectSecurityScheme(value)
-    }
-}
-#[doc = "Defines base properties shared by all security scheme objects."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines base properties shared by all security scheme objects.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"description\": {"]
-#[doc = "      \"description\": \"An optional description for the security scheme.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct SecuritySchemeBase {
-    #[doc = "An optional description for the security scheme."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub description: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&SecuritySchemeBase> for SecuritySchemeBase {
-    fn from(value: &SecuritySchemeBase) -> Self {
-        value.clone()
-    }
-}
-impl ::std::default::Default for SecuritySchemeBase {
-    fn default() -> Self {
-        Self {
-            description: Default::default(),
+impl ::std::fmt::Display for Role {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match *self {
+            Self::RoleUnspecified => f.write_str("ROLE_UNSPECIFIED"),
+            Self::RoleUser => f.write_str("ROLE_USER"),
+            Self::RoleAgent => f.write_str("ROLE_AGENT"),
         }
     }
 }
-impl SecuritySchemeBase {
-    pub fn builder() -> builder::SecuritySchemeBase {
-        Default::default()
+impl ::std::str::FromStr for Role {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        match value {
+            "ROLE_UNSPECIFIED" => Ok(Self::RoleUnspecified),
+            "ROLE_USER" => Ok(Self::RoleUser),
+            "ROLE_AGENT" => Ok(Self::RoleAgent),
+            _ => Err("invalid value".into()),
+        }
     }
 }
-#[doc = "Represents a JSON-RPC request for the `message/send` method."]
+impl ::std::convert::TryFrom<&str> for Role {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String> for Role {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String> for Role {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+#[doc = "`Security`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `message/send` method.\","]
+#[doc = "  \"title\": \"Security\","]
 #[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'message/send'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"message/send\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters for sending a message.\","]
-#[doc = "      \"$ref\": \"#/definitions/MessageSendParams\""]
+#[doc = "    \"schemes\": {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"additionalProperties\": {"]
+#[doc = "        \"$ref\": \"#/definitions/StringList\""]
+#[doc = "      },"]
+#[doc = "      \"propertyNames\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct SendMessageRequest {
-    #[doc = "The identifier for this request."]
-    pub id: SendMessageRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'message/send'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters for sending a message."]
-    pub params: MessageSendParams,
+#[serde(deny_unknown_fields)]
+pub struct Security {
+    #[serde(
+        default,
+        skip_serializing_if = ":: std :: collections :: HashMap::is_empty"
+    )]
+    pub schemes: ::std::collections::HashMap<::std::string::String, StringList>,
 }
-impl ::std::convert::From<&SendMessageRequest> for SendMessageRequest {
-    fn from(value: &SendMessageRequest) -> Self {
-        value.clone()
+impl ::std::default::Default for Security {
+    fn default() -> Self {
+        Self {
+            schemes: Default::default(),
+        }
     }
+}
+impl Security {
+    pub fn builder() -> builder::Security {
+        Default::default()
+    }
+}
+#[doc = "Defines a security scheme that can be used to secure an agent's endpoints.\n This is a discriminated union type based on the OpenAPI 3.2 Security Scheme Object.\n See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Security Scheme\","]
+#[doc = "  \"description\": \"Defines a security scheme that can be used to secure an agent's endpoints.\\n This is a discriminated union type based on the OpenAPI 3.2 Security Scheme Object.\\n See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"apiKeySecurityScheme\": {"]
+#[doc = "      \"description\": \"API key-based authentication.\","]
+#[doc = "      \"$ref\": \"#/definitions/APIKeySecurityScheme\""]
+#[doc = "    },"]
+#[doc = "    \"httpAuthSecurityScheme\": {"]
+#[doc = "      \"description\": \"HTTP authentication (Basic, Bearer, etc.).\","]
+#[doc = "      \"$ref\": \"#/definitions/HTTPAuthSecurityScheme\""]
+#[doc = "    },"]
+#[doc = "    \"mtlsSecurityScheme\": {"]
+#[doc = "      \"description\": \"Mutual TLS authentication.\","]
+#[doc = "      \"$ref\": \"#/definitions/MutualTlsSecurityScheme\""]
+#[doc = "    },"]
+#[doc = "    \"oauth2SecurityScheme\": {"]
+#[doc = "      \"description\": \"OAuth 2.0 authentication.\","]
+#[doc = "      \"$ref\": \"#/definitions/OAuth2SecurityScheme\""]
+#[doc = "    },"]
+#[doc = "    \"openIdConnectSecurityScheme\": {"]
+#[doc = "      \"description\": \"OpenID Connect authentication.\","]
+#[doc = "      \"$ref\": \"#/definitions/OpenIdConnectSecurityScheme\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityScheme {
+    #[doc = "API key-based authentication."]
+    #[serde(
+        rename = "apiKeySecurityScheme",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub api_key_security_scheme: ::std::option::Option<ApiKeySecurityScheme>,
+    #[doc = "HTTP authentication (Basic, Bearer, etc.)."]
+    #[serde(
+        rename = "httpAuthSecurityScheme",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub http_auth_security_scheme: ::std::option::Option<HttpAuthSecurityScheme>,
+    #[doc = "Mutual TLS authentication."]
+    #[serde(
+        rename = "mtlsSecurityScheme",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub mtls_security_scheme: ::std::option::Option<MutualTlsSecurityScheme>,
+    #[doc = "OAuth 2.0 authentication."]
+    #[serde(
+        rename = "oauth2SecurityScheme",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub oauth2_security_scheme: ::std::option::Option<OAuth2SecurityScheme>,
+    #[doc = "OpenID Connect authentication."]
+    #[serde(
+        rename = "openIdConnectSecurityScheme",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub open_id_connect_security_scheme: ::std::option::Option<OpenIdConnectSecurityScheme>,
+}
+impl ::std::default::Default for SecurityScheme {
+    fn default() -> Self {
+        Self {
+            api_key_security_scheme: Default::default(),
+            http_auth_security_scheme: Default::default(),
+            mtls_security_scheme: Default::default(),
+            oauth2_security_scheme: Default::default(),
+            open_id_connect_security_scheme: Default::default(),
+        }
+    }
+}
+impl SecurityScheme {
+    pub fn builder() -> builder::SecurityScheme {
+        Default::default()
+    }
+}
+#[doc = "Configuration of a send message request."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Send Message Configuration\","]
+#[doc = "  \"description\": \"Configuration of a send message request.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"blocking\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"acceptedOutputModes\": {"]
+#[doc = "      \"description\": \"A list of media types the client is prepared to accept for response parts. Agents SHOULD use this to tailor their output.\","]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
+#[doc = "    },"]
+#[doc = "    \"blocking\": {"]
+#[doc = "      \"description\": \"If true, the operation waits until the task reaches a terminal state before returning. Default is false.\","]
+#[doc = "      \"type\": \"boolean\""]
+#[doc = "    },"]
+#[doc = "    \"historyLength\": {"]
+#[doc = "      \"description\": \"The maximum number of messages to include in the history.\","]
+#[doc = "      \"type\": \"integer\","]
+#[doc = "      \"maximum\": 2147483647.0,"]
+#[doc = "      \"minimum\": -2147483648.0"]
+#[doc = "    },"]
+#[doc = "    \"pushNotificationConfig\": {"]
+#[doc = "      \"description\": \"Configuration for the agent to send push notifications for task updates.\","]
+#[doc = "      \"$ref\": \"#/definitions/PushNotificationConfig\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SendMessageConfiguration {
+    #[doc = "A list of media types the client is prepared to accept for response parts. Agents SHOULD use this to tailor their output."]
+    #[serde(
+        rename = "acceptedOutputModes",
+        default,
+        skip_serializing_if = "::std::vec::Vec::is_empty"
+    )]
+    pub accepted_output_modes: ::std::vec::Vec<::std::string::String>,
+    #[doc = "If true, the operation waits until the task reaches a terminal state before returning. Default is false."]
+    pub blocking: bool,
+    #[doc = "The maximum number of messages to include in the history."]
+    #[serde(
+        rename = "historyLength",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub history_length: ::std::option::Option<i32>,
+    #[doc = "Configuration for the agent to send push notifications for task updates."]
+    #[serde(
+        rename = "pushNotificationConfig",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub push_notification_config: ::std::option::Option<PushNotificationConfig>,
+}
+impl SendMessageConfiguration {
+    pub fn builder() -> builder::SendMessageConfiguration {
+        Default::default()
+    }
+}
+#[doc = "/////////// Request Messages ///////////\n Represents a request for the `message/send` method."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Send Message Request\","]
+#[doc = "  \"description\": \"/////////// Request Messages ///////////\\n Represents a request for the `message/send` method.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"tenant\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"configuration\": {"]
+#[doc = "      \"description\": \"Configuration for the send request.\","]
+#[doc = "      \"$ref\": \"#/definitions/SendMessageConfiguration\""]
+#[doc = "    },"]
+#[doc = "    \"message\": {"]
+#[doc = "      \"description\": \"The message to send to the agent.\","]
+#[doc = "      \"$ref\": \"#/definitions/Message\""]
+#[doc = "    },"]
+#[doc = "    \"metadata\": {"]
+#[doc = "      \"description\": \"A flexible key-value map for passing additional context or parameters.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
+#[doc = "    },"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SendMessageRequest {
+    #[doc = "Configuration for the send request."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub configuration: ::std::option::Option<SendMessageConfiguration>,
+    #[doc = "The message to send to the agent."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub message: ::std::option::Option<Message>,
+    #[doc = "A flexible key-value map for passing additional context or parameters."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
 }
 impl SendMessageRequest {
     pub fn builder() -> builder::SendMessageRequest {
         Default::default()
     }
 }
-#[doc = "The identifier for this request."]
+#[doc = "////// Response Messages ///////////"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendMessageRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for SendMessageRequestId {
-    fn from(value: &SendMessageRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for SendMessageRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for SendMessageRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SendMessageRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for SendMessageRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for SendMessageRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for SendMessageRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `message/send` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `message/send` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SendMessageSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendMessageResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    SendMessageSuccessResponse(SendMessageSuccessResponse),
-}
-impl ::std::convert::From<&Self> for SendMessageResponse {
-    fn from(value: &SendMessageResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for SendMessageResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<SendMessageSuccessResponse> for SendMessageResponse {
-    fn from(value: SendMessageSuccessResponse) -> Self {
-        Self::SendMessageSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `message/send` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `message/send` method.\","]
+#[doc = "  \"title\": \"Send Message Response\","]
+#[doc = "  \"description\": \"////// Response Messages ///////////\","]
 #[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
-#[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, which can be a direct reply Message or the initial Task object.\","]
-#[doc = "      \"anyOf\": ["]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/Task\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/Message\""]
-#[doc = "        }"]
-#[doc = "      ]"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct SendMessageSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: SendMessageSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, which can be a direct reply Message or the initial Task object."]
-    pub result: SendMessageSuccessResponseResult,
-}
-impl ::std::convert::From<&SendMessageSuccessResponse> for SendMessageSuccessResponse {
-    fn from(value: &SendMessageSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl SendMessageSuccessResponse {
-    pub fn builder() -> builder::SendMessageSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendMessageSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for SendMessageSuccessResponseId {
-    fn from(value: &SendMessageSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for SendMessageSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "The result, which can be a direct reply Message or the initial Task object."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The result, which can be a direct reply Message or the initial Task object.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/Task\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/Message\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendMessageSuccessResponseResult {
-    Task(Task),
-    Message(Message),
-}
-impl ::std::convert::From<&Self> for SendMessageSuccessResponseResult {
-    fn from(value: &SendMessageSuccessResponseResult) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<Task> for SendMessageSuccessResponseResult {
-    fn from(value: Task) -> Self {
-        Self::Task(value)
-    }
-}
-impl ::std::convert::From<Message> for SendMessageSuccessResponseResult {
-    fn from(value: Message) -> Self {
-        Self::Message(value)
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `message/stream` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `message/stream` method.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'message/stream'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"message/stream\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters for sending a message.\","]
-#[doc = "      \"$ref\": \"#/definitions/MessageSendParams\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct SendStreamingMessageRequest {
-    #[doc = "The identifier for this request."]
-    pub id: SendStreamingMessageRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'message/stream'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters for sending a message."]
-    pub params: MessageSendParams,
-}
-impl ::std::convert::From<&SendStreamingMessageRequest> for SendStreamingMessageRequest {
-    fn from(value: &SendStreamingMessageRequest) -> Self {
-        value.clone()
-    }
-}
-impl SendStreamingMessageRequest {
-    pub fn builder() -> builder::SendStreamingMessageRequest {
-        Default::default()
-    }
-}
-#[doc = "The identifier for this request."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendStreamingMessageRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for SendStreamingMessageRequestId {
-    fn from(value: &SendStreamingMessageRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for SendStreamingMessageRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for SendStreamingMessageRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SendStreamingMessageRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for SendStreamingMessageRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for SendStreamingMessageRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for SendStreamingMessageRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `message/stream` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `message/stream` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SendStreamingMessageSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendStreamingMessageResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    SendStreamingMessageSuccessResponse(SendStreamingMessageSuccessResponse),
-}
-impl ::std::convert::From<&Self> for SendStreamingMessageResponse {
-    fn from(value: &SendStreamingMessageResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for SendStreamingMessageResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<SendStreamingMessageSuccessResponse> for SendStreamingMessageResponse {
-    fn from(value: SendStreamingMessageSuccessResponse) -> Self {
-        Self::SendStreamingMessageSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `message/stream` method.\nThe server may send multiple response objects for a single request."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `message/stream` method.\\nThe server may send multiple response objects for a single request.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, which can be a Message, Task, or a streaming update event.\","]
-#[doc = "      \"anyOf\": ["]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/Task\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/Message\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/TaskStatusUpdateEvent\""]
-#[doc = "        },"]
-#[doc = "        {"]
-#[doc = "          \"$ref\": \"#/definitions/TaskArtifactUpdateEvent\""]
-#[doc = "        }"]
-#[doc = "      ]"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct SendStreamingMessageSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: SendStreamingMessageSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, which can be a Message, Task, or a streaming update event."]
-    pub result: SendStreamingMessageSuccessResponseResult,
-}
-impl ::std::convert::From<&SendStreamingMessageSuccessResponse>
-    for SendStreamingMessageSuccessResponse
-{
-    fn from(value: &SendStreamingMessageSuccessResponse) -> Self {
-        value.clone()
-    }
-}
-impl SendStreamingMessageSuccessResponse {
-    pub fn builder() -> builder::SendStreamingMessageSuccessResponse {
-        Default::default()
-    }
-}
-#[doc = "The identifier established by the client."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendStreamingMessageSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for SendStreamingMessageSuccessResponseId {
-    fn from(value: &SendStreamingMessageSuccessResponseId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<i64> for SendStreamingMessageSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "The result, which can be a Message, Task, or a streaming update event."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The result, which can be a Message, Task, or a streaming update event.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/Task\""]
-#[doc = "    },"]
-#[doc = "    {"]
+#[doc = "    \"message\": {"]
 #[doc = "      \"$ref\": \"#/definitions/Message\""]
 #[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskStatusUpdateEvent\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/TaskArtifactUpdateEvent\""]
+#[doc = "    \"task\": {"]
+#[doc = "      \"$ref\": \"#/definitions/Task\""]
 #[doc = "    }"]
-#[doc = "  ]"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SendStreamingMessageSuccessResponseResult {
-    Task(Task),
-    Message(Message),
-    TaskStatusUpdateEvent(TaskStatusUpdateEvent),
-    TaskArtifactUpdateEvent(TaskArtifactUpdateEvent),
+#[serde(deny_unknown_fields)]
+pub struct SendMessageResponse {
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub message: ::std::option::Option<Message>,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub task: ::std::option::Option<Task>,
 }
-impl ::std::convert::From<&Self> for SendStreamingMessageSuccessResponseResult {
-    fn from(value: &SendStreamingMessageSuccessResponseResult) -> Self {
-        value.clone()
+impl ::std::default::Default for SendMessageResponse {
+    fn default() -> Self {
+        Self {
+            message: Default::default(),
+            task: Default::default(),
+        }
     }
 }
-impl ::std::convert::From<Task> for SendStreamingMessageSuccessResponseResult {
-    fn from(value: Task) -> Self {
-        Self::Task(value)
+impl SendMessageResponse {
+    pub fn builder() -> builder::SendMessageResponse {
+        Default::default()
     }
 }
-impl ::std::convert::From<Message> for SendStreamingMessageSuccessResponseResult {
-    fn from(value: Message) -> Self {
-        Self::Message(value)
-    }
-}
-impl ::std::convert::From<TaskStatusUpdateEvent> for SendStreamingMessageSuccessResponseResult {
-    fn from(value: TaskStatusUpdateEvent) -> Self {
-        Self::TaskStatusUpdateEvent(value)
-    }
-}
-impl ::std::convert::From<TaskArtifactUpdateEvent> for SendStreamingMessageSuccessResponseResult {
-    fn from(value: TaskArtifactUpdateEvent) -> Self {
-        Self::TaskArtifactUpdateEvent(value)
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `tasks/pushNotificationConfig/set` method."]
+#[doc = "Represents a request for the `tasks/pushNotificationConfig/set` method."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/pushNotificationConfig/set` method.\","]
+#[doc = "  \"title\": \"Set Task Push Notification Config Request\","]
+#[doc = "  \"description\": \"Represents a request for the `tasks/pushNotificationConfig/set` method.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
+#[doc = "    \"config\","]
+#[doc = "    \"configId\","]
+#[doc = "    \"parent\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/pushNotificationConfig/set'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/pushNotificationConfig/set\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters for setting the push notification configuration.\","]
+#[doc = "    \"config\": {"]
+#[doc = "      \"description\": \"The configuration to create.\","]
 #[doc = "      \"$ref\": \"#/definitions/TaskPushNotificationConfig\""]
+#[doc = "    },"]
+#[doc = "    \"configId\": {"]
+#[doc = "      \"description\": \"The ID for the new config.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"parent\": {"]
+#[doc = "      \"description\": \"The parent task resource for this config.\\n Format: tasks/{task_id}\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SetTaskPushNotificationConfigRequest {
-    #[doc = "The identifier for this request."]
-    pub id: SetTaskPushNotificationConfigRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/pushNotificationConfig/set'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters for setting the push notification configuration."]
-    pub params: TaskPushNotificationConfig,
-}
-impl ::std::convert::From<&SetTaskPushNotificationConfigRequest>
-    for SetTaskPushNotificationConfigRequest
-{
-    fn from(value: &SetTaskPushNotificationConfigRequest) -> Self {
-        value.clone()
-    }
+    #[doc = "The configuration to create."]
+    pub config: TaskPushNotificationConfig,
+    #[doc = "The ID for the new config."]
+    #[serde(rename = "configId")]
+    pub config_id: ::std::string::String,
+    #[doc = "The parent task resource for this config.\n Format: tasks/{task_id}"]
+    pub parent: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub tenant: ::std::option::Option<::std::string::String>,
 }
 impl SetTaskPushNotificationConfigRequest {
     pub fn builder() -> builder::SetTaskPushNotificationConfigRequest {
         Default::default()
     }
 }
-#[doc = "The identifier for this request."]
+#[doc = "A wrapper object used in streaming operations to encapsulate different types of response data."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SetTaskPushNotificationConfigRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for SetTaskPushNotificationConfigRequestId {
-    fn from(value: &SetTaskPushNotificationConfigRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for SetTaskPushNotificationConfigRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for SetTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for SetTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for SetTaskPushNotificationConfigRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for SetTaskPushNotificationConfigRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for SetTaskPushNotificationConfigRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Represents a JSON-RPC response for the `tasks/pushNotificationConfig/set` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC response for the `tasks/pushNotificationConfig/set` method.\","]
-#[doc = "  \"anyOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/JSONRPCErrorResponse\""]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"$ref\": \"#/definitions/SetTaskPushNotificationConfigSuccessResponse\""]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SetTaskPushNotificationConfigResponse {
-    JsonrpcErrorResponse(JsonrpcErrorResponse),
-    SetTaskPushNotificationConfigSuccessResponse(SetTaskPushNotificationConfigSuccessResponse),
-}
-impl ::std::convert::From<&Self> for SetTaskPushNotificationConfigResponse {
-    fn from(value: &SetTaskPushNotificationConfigResponse) -> Self {
-        value.clone()
-    }
-}
-impl ::std::convert::From<JsonrpcErrorResponse> for SetTaskPushNotificationConfigResponse {
-    fn from(value: JsonrpcErrorResponse) -> Self {
-        Self::JsonrpcErrorResponse(value)
-    }
-}
-impl ::std::convert::From<SetTaskPushNotificationConfigSuccessResponse>
-    for SetTaskPushNotificationConfigResponse
-{
-    fn from(value: SetTaskPushNotificationConfigSuccessResponse) -> Self {
-        Self::SetTaskPushNotificationConfigSuccessResponse(value)
-    }
-}
-#[doc = "Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/set` method."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/set` method.\","]
+#[doc = "  \"title\": \"Stream Response\","]
+#[doc = "  \"description\": \"A wrapper object used in streaming operations to encapsulate different types of response data.\","]
 #[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"result\""]
-#[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier established by the client.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\","]
-#[doc = "        \"null\""]
-#[doc = "      ]"]
+#[doc = "    \"artifactUpdate\": {"]
+#[doc = "      \"description\": \"An event indicating a task artifact update.\","]
+#[doc = "      \"$ref\": \"#/definitions/TaskArtifactUpdateEvent\""]
 #[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
+#[doc = "    \"message\": {"]
+#[doc = "      \"description\": \"A Message object containing a message from the agent.\","]
+#[doc = "      \"$ref\": \"#/definitions/Message\""]
 #[doc = "    },"]
-#[doc = "    \"result\": {"]
-#[doc = "      \"description\": \"The result, containing the configured push notification settings.\","]
-#[doc = "      \"$ref\": \"#/definitions/TaskPushNotificationConfig\""]
+#[doc = "    \"statusUpdate\": {"]
+#[doc = "      \"description\": \"An event indicating a task status update.\","]
+#[doc = "      \"$ref\": \"#/definitions/TaskStatusUpdateEvent\""]
+#[doc = "    },"]
+#[doc = "    \"task\": {"]
+#[doc = "      \"description\": \"A Task object containing the current state of the task.\","]
+#[doc = "      \"$ref\": \"#/definitions/Task\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct SetTaskPushNotificationConfigSuccessResponse {
-    #[doc = "The identifier established by the client."]
-    pub id: SetTaskPushNotificationConfigSuccessResponseId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The result, containing the configured push notification settings."]
-    pub result: TaskPushNotificationConfig,
+#[serde(deny_unknown_fields)]
+pub struct StreamResponse {
+    #[doc = "An event indicating a task artifact update."]
+    #[serde(
+        rename = "artifactUpdate",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub artifact_update: ::std::option::Option<TaskArtifactUpdateEvent>,
+    #[doc = "A Message object containing a message from the agent."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub message: ::std::option::Option<Message>,
+    #[doc = "An event indicating a task status update."]
+    #[serde(
+        rename = "statusUpdate",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub status_update: ::std::option::Option<TaskStatusUpdateEvent>,
+    #[doc = "A Task object containing the current state of the task."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub task: ::std::option::Option<Task>,
 }
-impl ::std::convert::From<&SetTaskPushNotificationConfigSuccessResponse>
-    for SetTaskPushNotificationConfigSuccessResponse
-{
-    fn from(value: &SetTaskPushNotificationConfigSuccessResponse) -> Self {
-        value.clone()
+impl ::std::default::Default for StreamResponse {
+    fn default() -> Self {
+        Self {
+            artifact_update: Default::default(),
+            message: Default::default(),
+            status_update: Default::default(),
+            task: Default::default(),
+        }
     }
 }
-impl SetTaskPushNotificationConfigSuccessResponse {
-    pub fn builder() -> builder::SetTaskPushNotificationConfigSuccessResponse {
+impl StreamResponse {
+    pub fn builder() -> builder::StreamResponse {
         Default::default()
     }
 }
-#[doc = "The identifier established by the client."]
+#[doc = "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"The identifier established by the client.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\","]
-#[doc = "    \"null\""]
-#[doc = "  ]"]
+#[doc = "  \"title\": \"String List\","]
+#[doc = "  \"description\": \"protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"list\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum SetTaskPushNotificationConfigSuccessResponseId {
-    Null,
-    String(::std::string::String),
-    Integer(i64),
+#[serde(deny_unknown_fields)]
+pub struct StringList {
+    #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+    pub list: ::std::vec::Vec<::std::string::String>,
 }
-impl ::std::convert::From<&Self> for SetTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: &SetTaskPushNotificationConfigSuccessResponseId) -> Self {
-        value.clone()
+impl ::std::default::Default for StringList {
+    fn default() -> Self {
+        Self {
+            list: Default::default(),
+        }
     }
 }
-impl ::std::convert::From<i64> for SetTaskPushNotificationConfigSuccessResponseId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
+impl StringList {
+    pub fn builder() -> builder::StringList {
+        Default::default()
     }
 }
-#[doc = "Represents a single, stateful operation or conversation between a client and an agent."]
+#[doc = "`Struct`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a single, stateful operation or conversation between a client and an agent.\","]
+#[doc = "  \"title\": \"Struct\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct Struct(pub ::serde_json::Map<::std::string::String, ::serde_json::Value>);
+impl ::std::ops::Deref for Struct {
+    type Target = ::serde_json::Map<::std::string::String, ::serde_json::Value>;
+    fn deref(&self) -> &::serde_json::Map<::std::string::String, ::serde_json::Value> {
+        &self.0
+    }
+}
+impl ::std::convert::From<Struct>
+    for ::serde_json::Map<::std::string::String, ::serde_json::Value>
+{
+    fn from(value: Struct) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<::serde_json::Map<::std::string::String, ::serde_json::Value>>
+    for Struct
+{
+    fn from(value: ::serde_json::Map<::std::string::String, ::serde_json::Value>) -> Self {
+        Self(value)
+    }
+}
+#[doc = "`SubscribeToTaskRequest`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Subscribe To Task Request\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"name\","]
+#[doc = "    \"tenant\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"name\": {"]
+#[doc = "      \"description\": \"The resource name of the task to subscribe to.\\n Format: tasks/{task_id}\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
+#[doc = "    \"tenant\": {"]
+#[doc = "      \"description\": \"Optional tenant, provided as a path parameter.\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SubscribeToTaskRequest {
+    #[doc = "The resource name of the task to subscribe to.\n Format: tasks/{task_id}"]
+    pub name: ::std::string::String,
+    #[doc = "Optional tenant, provided as a path parameter."]
+    pub tenant: ::std::string::String,
+}
+impl SubscribeToTaskRequest {
+    pub fn builder() -> builder::SubscribeToTaskRequest {
+        Default::default()
+    }
+}
+#[doc = "Task is the core unit of action for A2A. It has a current status\n and when results are created for the task they are stored in the\n artifact. If there are multiple turns for a task, these are stored in\n history."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"title\": \"Task\","]
+#[doc = "  \"description\": \"Task is the core unit of action for A2A. It has a current status\\n and when results are created for the task they are stored in the\\n artifact. If there are multiple turns for a task, these are stored in\\n history.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"contextId\","]
 #[doc = "    \"id\","]
-#[doc = "    \"kind\","]
 #[doc = "    \"status\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"artifacts\": {"]
-#[doc = "      \"description\": \"A collection of artifacts generated by the agent during the execution of the task.\","]
+#[doc = "      \"description\": \"A set of output artifacts for a Task.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/Artifact\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"contextId\": {"]
-#[doc = "      \"description\": \"A server-generated identifier for maintaining context across multiple related tasks or interactions.\","]
+#[doc = "      \"description\": \"Unique identifier (e.g. UUID) for the contextual collection of interactions\\n (tasks and messages). Created by the A2A server.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"history\": {"]
-#[doc = "      \"description\": \"An array of messages exchanged during the task, representing the conversation history.\","]
+#[doc = "      \"description\": \"protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\\n The history of interactions from a task.\","]
 #[doc = "      \"type\": \"array\","]
 #[doc = "      \"items\": {"]
 #[doc = "        \"$ref\": \"#/definitions/Message\""]
 #[doc = "      }"]
 #[doc = "    },"]
 #[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"A unique identifier for the task, generated by the client for a new task or provided by the agent.\","]
+#[doc = "      \"description\": \"Unique identifier (e.g. UUID) for the task, generated by the server for a\\n new task.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this object, used as a discriminator. Always 'task' for a Task.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"task\""]
-#[doc = "    },"]
 #[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata for extensions. The key is an extension-specific identifier.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"description\": \"protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\\n A key/value object to store custom metadata about a task.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"status\": {"]
-#[doc = "      \"description\": \"The current status of the task, including its state and a descriptive message.\","]
+#[doc = "      \"description\": \"The current status of a Task, including state and a message.\","]
 #[doc = "      \"$ref\": \"#/definitions/TaskStatus\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Task {
-    #[doc = "A collection of artifacts generated by the agent during the execution of the task."]
+    #[doc = "A set of output artifacts for a Task."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub artifacts: ::std::vec::Vec<Artifact>,
-    #[doc = "A server-generated identifier for maintaining context across multiple related tasks or interactions."]
+    #[doc = "Unique identifier (e.g. UUID) for the contextual collection of interactions\n (tasks and messages). Created by the A2A server."]
     #[serde(rename = "contextId")]
     pub context_id: ::std::string::String,
-    #[doc = "An array of messages exchanged during the task, representing the conversation history."]
+    #[doc = "protolint:disable REPEATED_FIELD_NAMES_PLURALIZED\n The history of interactions from a task."]
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub history: ::std::vec::Vec<Message>,
-    #[doc = "A unique identifier for the task, generated by the client for a new task or provided by the agent."]
+    #[doc = "Unique identifier (e.g. UUID) for the task, generated by the server for a\n new task."]
     pub id: ::std::string::String,
-    #[doc = "The type of this object, used as a discriminator. Always 'task' for a Task."]
-    pub kind: ::std::string::String,
-    #[doc = "Optional metadata for extensions. The key is an extension-specific identifier."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The current status of the task, including its state and a descriptive message."]
+    #[doc = "protolint:enable REPEATED_FIELD_NAMES_PLURALIZED\n A key/value object to store custom metadata about a task."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
+    #[doc = "The current status of a Task, including state and a message."]
     pub status: TaskStatus,
-}
-impl ::std::convert::From<&Task> for Task {
-    fn from(value: &Task) -> Self {
-        value.clone()
-    }
 }
 impl Task {
     pub fn builder() -> builder::Task {
         Default::default()
     }
 }
-#[doc = "An event sent by the agent to notify the client that an artifact has been\ngenerated or updated. This is typically used in streaming models."]
+#[doc = "TaskArtifactUpdateEvent represents a task delta where an artifact has\n been generated."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"An event sent by the agent to notify the client that an artifact has been\\ngenerated or updated. This is typically used in streaming models.\","]
+#[doc = "  \"title\": \"Task Artifact Update Event\","]
+#[doc = "  \"description\": \"TaskArtifactUpdateEvent represents a task delta where an artifact has\\n been generated.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"artifact\","]
 #[doc = "    \"contextId\","]
-#[doc = "    \"kind\","]
 #[doc = "    \"taskId\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"append\": {"]
-#[doc = "      \"description\": \"If true, the content of this artifact should be appended to a previously sent artifact with the same ID.\","]
+#[doc = "      \"description\": \"If true, the content of this artifact should be appended to a previously\\n sent artifact with the same ID.\","]
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    },"]
 #[doc = "    \"artifact\": {"]
@@ -6162,43 +2906,38 @@ impl Task {
 #[doc = "      \"$ref\": \"#/definitions/Artifact\""]
 #[doc = "    },"]
 #[doc = "    \"contextId\": {"]
-#[doc = "      \"description\": \"The context ID associated with the task.\","]
+#[doc = "      \"description\": \"The id of the context that this task belongs to.\","]
 #[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this event, used as a discriminator. Always 'artifact-update'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"artifact-update\""]
 #[doc = "    },"]
 #[doc = "    \"lastChunk\": {"]
 #[doc = "      \"description\": \"If true, this is the final chunk of the artifact.\","]
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    },"]
 #[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata for extensions.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"description\": \"Optional metadata associated with the artifact update.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"taskId\": {"]
-#[doc = "      \"description\": \"The ID of the task this artifact belongs to.\","]
+#[doc = "      \"description\": \"The id of the task for this artifact.\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct TaskArtifactUpdateEvent {
-    #[doc = "If true, the content of this artifact should be appended to a previously sent artifact with the same ID."]
+    #[doc = "If true, the content of this artifact should be appended to a previously\n sent artifact with the same ID."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub append: ::std::option::Option<bool>,
     #[doc = "The artifact that was generated or updated."]
     pub artifact: Artifact,
-    #[doc = "The context ID associated with the task."]
+    #[doc = "The id of the context that this task belongs to."]
     #[serde(rename = "contextId")]
     pub context_id: ::std::string::String,
-    #[doc = "The type of this event, used as a discriminator. Always 'artifact-update'."]
-    pub kind: ::std::string::String,
     #[doc = "If true, this is the final chunk of the artifact."]
     #[serde(
         rename = "lastChunk",
@@ -6206,415 +2945,79 @@ pub struct TaskArtifactUpdateEvent {
         skip_serializing_if = "::std::option::Option::is_none"
     )]
     pub last_chunk: ::std::option::Option<bool>,
-    #[doc = "Optional metadata for extensions."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The ID of the task this artifact belongs to."]
+    #[doc = "Optional metadata associated with the artifact update."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
+    #[doc = "The id of the task for this artifact."]
     #[serde(rename = "taskId")]
     pub task_id: ::std::string::String,
-}
-impl ::std::convert::From<&TaskArtifactUpdateEvent> for TaskArtifactUpdateEvent {
-    fn from(value: &TaskArtifactUpdateEvent) -> Self {
-        value.clone()
-    }
 }
 impl TaskArtifactUpdateEvent {
     pub fn builder() -> builder::TaskArtifactUpdateEvent {
         Default::default()
     }
 }
-#[doc = "Defines parameters containing a task ID, used for simple task operations."]
+#[doc = "A container associating a push notification configuration with a specific\n task."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Defines parameters containing a task ID, used for simple task operations.\","]
+#[doc = "  \"title\": \"Task Push Notification Config\","]
+#[doc = "  \"description\": \"A container associating a push notification configuration with a specific\\n task.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
-#[doc = "    \"id\""]
+#[doc = "    \"name\","]
+#[doc = "    \"pushNotificationConfig\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The unique identifier of the task.\","]
+#[doc = "    \"name\": {"]
+#[doc = "      \"description\": \"The resource name of the config.\\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with the request.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TaskIdParams {
-    #[doc = "The unique identifier of the task."]
-    pub id: ::std::string::String,
-    #[doc = "Optional metadata associated with the request."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&TaskIdParams> for TaskIdParams {
-    fn from(value: &TaskIdParams) -> Self {
-        value.clone()
-    }
-}
-impl TaskIdParams {
-    pub fn builder() -> builder::TaskIdParams {
-        Default::default()
-    }
-}
-#[doc = "An A2A-specific error indicating that the task is in a state where it cannot be canceled."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An A2A-specific error indicating that the task is in a state where it cannot be canceled.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for a task that cannot be canceled.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32002"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Task cannot be canceled\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TaskNotCancelableError {
-    #[doc = "The error code for a task that cannot be canceled."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&TaskNotCancelableError> for TaskNotCancelableError {
-    fn from(value: &TaskNotCancelableError) -> Self {
-        value.clone()
-    }
-}
-impl TaskNotCancelableError {
-    pub fn builder() -> builder::TaskNotCancelableError {
-        Default::default()
-    }
-}
-#[doc = "An A2A-specific error indicating that the requested task ID was not found."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An A2A-specific error indicating that the requested task ID was not found.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for a task not found error.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32001"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"Task not found\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TaskNotFoundError {
-    #[doc = "The error code for a task not found error."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&TaskNotFoundError> for TaskNotFoundError {
-    fn from(value: &TaskNotFoundError) -> Self {
-        value.clone()
-    }
-}
-impl TaskNotFoundError {
-    pub fn builder() -> builder::TaskNotFoundError {
-        Default::default()
-    }
-}
-#[doc = "A container associating a push notification configuration with a specific task."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"A container associating a push notification configuration with a specific task.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"pushNotificationConfig\","]
-#[doc = "    \"taskId\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
 #[doc = "    \"pushNotificationConfig\": {"]
-#[doc = "      \"description\": \"The push notification configuration for this task.\","]
+#[doc = "      \"description\": \"The push notification configuration details.\","]
 #[doc = "      \"$ref\": \"#/definitions/PushNotificationConfig\""]
-#[doc = "    },"]
-#[doc = "    \"taskId\": {"]
-#[doc = "      \"description\": \"The ID of the task.\","]
-#[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct TaskPushNotificationConfig {
-    #[doc = "The push notification configuration for this task."]
+    #[doc = "The resource name of the config.\n Format: tasks/{task_id}/pushNotificationConfigs/{config_id}"]
+    pub name: ::std::string::String,
+    #[doc = "The push notification configuration details."]
     #[serde(rename = "pushNotificationConfig")]
     pub push_notification_config: PushNotificationConfig,
-    #[doc = "The ID of the task."]
-    #[serde(rename = "taskId")]
-    pub task_id: ::std::string::String,
-}
-impl ::std::convert::From<&TaskPushNotificationConfig> for TaskPushNotificationConfig {
-    fn from(value: &TaskPushNotificationConfig) -> Self {
-        value.clone()
-    }
 }
 impl TaskPushNotificationConfig {
     pub fn builder() -> builder::TaskPushNotificationConfig {
         Default::default()
     }
 }
-#[doc = "Defines parameters for querying a task, with an option to limit history length."]
+#[doc = "Filter tasks by their current status state."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Defines parameters for querying a task, with an option to limit history length.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"historyLength\": {"]
-#[doc = "      \"description\": \"The number of most recent messages from the task's history to retrieve.\","]
-#[doc = "      \"type\": \"integer\""]
-#[doc = "    },"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The unique identifier of the task.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with the request.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TaskQueryParams {
-    #[doc = "The number of most recent messages from the task's history to retrieve."]
-    #[serde(
-        rename = "historyLength",
-        default,
-        skip_serializing_if = "::std::option::Option::is_none"
-    )]
-    pub history_length: ::std::option::Option<i64>,
-    #[doc = "The unique identifier of the task."]
-    pub id: ::std::string::String,
-    #[doc = "Optional metadata associated with the request."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-}
-impl ::std::convert::From<&TaskQueryParams> for TaskQueryParams {
-    fn from(value: &TaskQueryParams) -> Self {
-        value.clone()
-    }
-}
-impl TaskQueryParams {
-    pub fn builder() -> builder::TaskQueryParams {
-        Default::default()
-    }
-}
-#[doc = "Represents a JSON-RPC request for the `tasks/resubscribe` method, used to resume a streaming connection."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Represents a JSON-RPC request for the `tasks/resubscribe` method, used to resume a streaming connection.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"id\","]
-#[doc = "    \"jsonrpc\","]
-#[doc = "    \"method\","]
-#[doc = "    \"params\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"id\": {"]
-#[doc = "      \"description\": \"The identifier for this request.\","]
-#[doc = "      \"type\": ["]
-#[doc = "        \"string\","]
-#[doc = "        \"integer\""]
-#[doc = "      ]"]
-#[doc = "    },"]
-#[doc = "    \"jsonrpc\": {"]
-#[doc = "      \"description\": \"The version of the JSON-RPC protocol. MUST be exactly \\\"2.0\\\".\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"2.0\""]
-#[doc = "    },"]
-#[doc = "    \"method\": {"]
-#[doc = "      \"description\": \"The method name. Must be 'tasks/resubscribe'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"tasks/resubscribe\""]
-#[doc = "    },"]
-#[doc = "    \"params\": {"]
-#[doc = "      \"description\": \"The parameters identifying the task to resubscribe to.\","]
-#[doc = "      \"$ref\": \"#/definitions/TaskIdParams\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TaskResubscriptionRequest {
-    #[doc = "The identifier for this request."]
-    pub id: TaskResubscriptionRequestId,
-    #[doc = "The version of the JSON-RPC protocol. MUST be exactly \"2.0\"."]
-    pub jsonrpc: ::std::string::String,
-    #[doc = "The method name. Must be 'tasks/resubscribe'."]
-    pub method: ::std::string::String,
-    #[doc = "The parameters identifying the task to resubscribe to."]
-    pub params: TaskIdParams,
-}
-impl ::std::convert::From<&TaskResubscriptionRequest> for TaskResubscriptionRequest {
-    fn from(value: &TaskResubscriptionRequest) -> Self {
-        value.clone()
-    }
-}
-impl TaskResubscriptionRequest {
-    pub fn builder() -> builder::TaskResubscriptionRequest {
-        Default::default()
-    }
-}
-#[doc = "The identifier for this request."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"The identifier for this request.\","]
-#[doc = "  \"type\": ["]
-#[doc = "    \"string\","]
-#[doc = "    \"integer\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum TaskResubscriptionRequestId {
-    String(::std::string::String),
-    Integer(i64),
-}
-impl ::std::convert::From<&Self> for TaskResubscriptionRequestId {
-    fn from(value: &TaskResubscriptionRequestId) -> Self {
-        value.clone()
-    }
-}
-impl ::std::str::FromStr for TaskResubscriptionRequestId {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        if let Ok(v) = value.parse() {
-            Ok(Self::String(v))
-        } else if let Ok(v) = value.parse() {
-            Ok(Self::Integer(v))
-        } else {
-            Err("string conversion failed for all variants".into())
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for TaskResubscriptionRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TaskResubscriptionRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for TaskResubscriptionRequestId {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::fmt::Display for TaskResubscriptionRequestId {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            Self::String(x) => x.fmt(f),
-            Self::Integer(x) => x.fmt(f),
-        }
-    }
-}
-impl ::std::convert::From<i64> for TaskResubscriptionRequestId {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-#[doc = "Defines the lifecycle states of a Task."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Defines the lifecycle states of a Task.\","]
+#[doc = "  \"title\": \"Task State\","]
+#[doc = "  \"description\": \"Filter tasks by their current status state.\","]
 #[doc = "  \"type\": \"string\","]
 #[doc = "  \"enum\": ["]
-#[doc = "    \"submitted\","]
-#[doc = "    \"working\","]
-#[doc = "    \"input-required\","]
-#[doc = "    \"completed\","]
-#[doc = "    \"canceled\","]
-#[doc = "    \"failed\","]
-#[doc = "    \"rejected\","]
-#[doc = "    \"auth-required\","]
-#[doc = "    \"unknown\""]
+#[doc = "    \"TASK_STATE_UNSPECIFIED\","]
+#[doc = "    \"TASK_STATE_SUBMITTED\","]
+#[doc = "    \"TASK_STATE_WORKING\","]
+#[doc = "    \"TASK_STATE_COMPLETED\","]
+#[doc = "    \"TASK_STATE_FAILED\","]
+#[doc = "    \"TASK_STATE_CANCELLED\","]
+#[doc = "    \"TASK_STATE_INPUT_REQUIRED\","]
+#[doc = "    \"TASK_STATE_REJECTED\","]
+#[doc = "    \"TASK_STATE_AUTH_REQUIRED\""]
 #[doc = "  ]"]
 #[doc = "}"]
 #[doc = r" ```"]
@@ -6632,42 +3035,37 @@ impl ::std::convert::From<i64> for TaskResubscriptionRequestId {
     PartialOrd,
 )]
 pub enum TaskState {
-    #[serde(rename = "submitted")]
-    Submitted,
-    #[serde(rename = "working")]
-    Working,
-    #[serde(rename = "input-required")]
-    InputRequired,
-    #[serde(rename = "completed")]
-    Completed,
-    #[serde(rename = "canceled")]
-    Canceled,
-    #[serde(rename = "failed")]
-    Failed,
-    #[serde(rename = "rejected")]
-    Rejected,
-    #[serde(rename = "auth-required")]
-    AuthRequired,
-    #[serde(rename = "unknown")]
-    Unknown,
-}
-impl ::std::convert::From<&Self> for TaskState {
-    fn from(value: &TaskState) -> Self {
-        value.clone()
-    }
+    #[serde(rename = "TASK_STATE_UNSPECIFIED")]
+    TaskStateUnspecified,
+    #[serde(rename = "TASK_STATE_SUBMITTED")]
+    TaskStateSubmitted,
+    #[serde(rename = "TASK_STATE_WORKING")]
+    TaskStateWorking,
+    #[serde(rename = "TASK_STATE_COMPLETED")]
+    TaskStateCompleted,
+    #[serde(rename = "TASK_STATE_FAILED")]
+    TaskStateFailed,
+    #[serde(rename = "TASK_STATE_CANCELLED")]
+    TaskStateCancelled,
+    #[serde(rename = "TASK_STATE_INPUT_REQUIRED")]
+    TaskStateInputRequired,
+    #[serde(rename = "TASK_STATE_REJECTED")]
+    TaskStateRejected,
+    #[serde(rename = "TASK_STATE_AUTH_REQUIRED")]
+    TaskStateAuthRequired,
 }
 impl ::std::fmt::Display for TaskState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
-            Self::Submitted => write!(f, "submitted"),
-            Self::Working => write!(f, "working"),
-            Self::InputRequired => write!(f, "input-required"),
-            Self::Completed => write!(f, "completed"),
-            Self::Canceled => write!(f, "canceled"),
-            Self::Failed => write!(f, "failed"),
-            Self::Rejected => write!(f, "rejected"),
-            Self::AuthRequired => write!(f, "auth-required"),
-            Self::Unknown => write!(f, "unknown"),
+            Self::TaskStateUnspecified => f.write_str("TASK_STATE_UNSPECIFIED"),
+            Self::TaskStateSubmitted => f.write_str("TASK_STATE_SUBMITTED"),
+            Self::TaskStateWorking => f.write_str("TASK_STATE_WORKING"),
+            Self::TaskStateCompleted => f.write_str("TASK_STATE_COMPLETED"),
+            Self::TaskStateFailed => f.write_str("TASK_STATE_FAILED"),
+            Self::TaskStateCancelled => f.write_str("TASK_STATE_CANCELLED"),
+            Self::TaskStateInputRequired => f.write_str("TASK_STATE_INPUT_REQUIRED"),
+            Self::TaskStateRejected => f.write_str("TASK_STATE_REJECTED"),
+            Self::TaskStateAuthRequired => f.write_str("TASK_STATE_AUTH_REQUIRED"),
         }
     }
 }
@@ -6675,15 +3073,15 @@ impl ::std::str::FromStr for TaskState {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         match value {
-            "submitted" => Ok(Self::Submitted),
-            "working" => Ok(Self::Working),
-            "input-required" => Ok(Self::InputRequired),
-            "completed" => Ok(Self::Completed),
-            "canceled" => Ok(Self::Canceled),
-            "failed" => Ok(Self::Failed),
-            "rejected" => Ok(Self::Rejected),
-            "auth-required" => Ok(Self::AuthRequired),
-            "unknown" => Ok(Self::Unknown),
+            "TASK_STATE_UNSPECIFIED" => Ok(Self::TaskStateUnspecified),
+            "TASK_STATE_SUBMITTED" => Ok(Self::TaskStateSubmitted),
+            "TASK_STATE_WORKING" => Ok(Self::TaskStateWorking),
+            "TASK_STATE_COMPLETED" => Ok(Self::TaskStateCompleted),
+            "TASK_STATE_FAILED" => Ok(Self::TaskStateFailed),
+            "TASK_STATE_CANCELLED" => Ok(Self::TaskStateCancelled),
+            "TASK_STATE_INPUT_REQUIRED" => Ok(Self::TaskStateInputRequired),
+            "TASK_STATE_REJECTED" => Ok(Self::TaskStateRejected),
+            "TASK_STATE_AUTH_REQUIRED" => Ok(Self::TaskStateAuthRequired),
             _ => Err("invalid value".into()),
         }
     }
@@ -6710,532 +3108,188 @@ impl ::std::convert::TryFrom<::std::string::String> for TaskState {
         value.parse()
     }
 }
-#[doc = "Represents the status of a task at a specific point in time."]
+#[doc = "A container for the status of a task"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents the status of a task at a specific point in time.\","]
+#[doc = "  \"title\": \"Task Status\","]
+#[doc = "  \"description\": \"A container for the status of a task\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"state\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"An optional, human-readable message providing more details about the current status.\","]
+#[doc = "      \"description\": \"A message associated with the status.\","]
 #[doc = "      \"$ref\": \"#/definitions/Message\""]
 #[doc = "    },"]
 #[doc = "    \"state\": {"]
-#[doc = "      \"description\": \"The current state of the task's lifecycle.\","]
-#[doc = "      \"$ref\": \"#/definitions/TaskState\""]
+#[doc = "      \"title\": \"Task State\","]
+#[doc = "      \"description\": \"The current state of this task.\","]
+#[doc = "      \"type\": \"string\","]
+#[doc = "      \"enum\": ["]
+#[doc = "        \"TASK_STATE_UNSPECIFIED\","]
+#[doc = "        \"TASK_STATE_SUBMITTED\","]
+#[doc = "        \"TASK_STATE_WORKING\","]
+#[doc = "        \"TASK_STATE_COMPLETED\","]
+#[doc = "        \"TASK_STATE_FAILED\","]
+#[doc = "        \"TASK_STATE_CANCELLED\","]
+#[doc = "        \"TASK_STATE_INPUT_REQUIRED\","]
+#[doc = "        \"TASK_STATE_REJECTED\","]
+#[doc = "        \"TASK_STATE_AUTH_REQUIRED\""]
+#[doc = "      ]"]
 #[doc = "    },"]
 #[doc = "    \"timestamp\": {"]
-#[doc = "      \"description\": \"An ISO 8601 datetime string indicating when this status was recorded.\","]
-#[doc = "      \"examples\": ["]
-#[doc = "        \"2023-10-27T10:00:00Z\""]
-#[doc = "      ],"]
-#[doc = "      \"type\": \"string\""]
+#[doc = "      \"description\": \"ISO 8601 Timestamp when the status was recorded.\\n Example: \\\"2023-10-27T10:00:00Z\\\"\","]
+#[doc = "      \"$ref\": \"#/definitions/Timestamp\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct TaskStatus {
-    #[doc = "An optional, human-readable message providing more details about the current status."]
+    #[doc = "A message associated with the status."]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub message: ::std::option::Option<Message>,
-    #[doc = "The current state of the task's lifecycle."]
+    #[doc = "The current state of this task."]
     pub state: TaskState,
-    #[doc = "An ISO 8601 datetime string indicating when this status was recorded."]
+    #[doc = "ISO 8601 Timestamp when the status was recorded.\n Example: \"2023-10-27T10:00:00Z\""]
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub timestamp: ::std::option::Option<::std::string::String>,
-}
-impl ::std::convert::From<&TaskStatus> for TaskStatus {
-    fn from(value: &TaskStatus) -> Self {
-        value.clone()
-    }
+    pub timestamp: ::std::option::Option<Timestamp>,
 }
 impl TaskStatus {
     pub fn builder() -> builder::TaskStatus {
         Default::default()
     }
 }
-#[doc = "An event sent by the agent to notify the client of a change in a task's status.\nThis is typically used in streaming or subscription models."]
+#[doc = "An event sent by the agent to notify the client of a change in a task's\n status."]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"An event sent by the agent to notify the client of a change in a task's status.\\nThis is typically used in streaming or subscription models.\","]
+#[doc = "  \"title\": \"Task Status Update Event\","]
+#[doc = "  \"description\": \"An event sent by the agent to notify the client of a change in a task's\\n status.\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"required\": ["]
 #[doc = "    \"contextId\","]
 #[doc = "    \"final\","]
-#[doc = "    \"kind\","]
 #[doc = "    \"status\","]
 #[doc = "    \"taskId\""]
 #[doc = "  ],"]
 #[doc = "  \"properties\": {"]
 #[doc = "    \"contextId\": {"]
-#[doc = "      \"description\": \"The context ID associated with the task.\","]
+#[doc = "      \"description\": \"The id of the context that the task belongs to\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
 #[doc = "    \"final\": {"]
 #[doc = "      \"description\": \"If true, this is the final event in the stream for this interaction.\","]
 #[doc = "      \"type\": \"boolean\""]
 #[doc = "    },"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this event, used as a discriminator. Always 'status-update'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"status-update\""]
-#[doc = "    },"]
 #[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata for extensions.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
+#[doc = "      \"description\": \"Optional metadata to associate with the task update.\","]
+#[doc = "      \"$ref\": \"#/definitions/Struct\""]
 #[doc = "    },"]
 #[doc = "    \"status\": {"]
 #[doc = "      \"description\": \"The new status of the task.\","]
 #[doc = "      \"$ref\": \"#/definitions/TaskStatus\""]
 #[doc = "    },"]
 #[doc = "    \"taskId\": {"]
-#[doc = "      \"description\": \"The ID of the task that was updated.\","]
+#[doc = "      \"description\": \"The id of the task that is changed\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false,"]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct TaskStatusUpdateEvent {
-    #[doc = "The context ID associated with the task."]
+    #[doc = "The id of the context that the task belongs to"]
     #[serde(rename = "contextId")]
     pub context_id: ::std::string::String,
     #[doc = "If true, this is the final event in the stream for this interaction."]
     #[serde(rename = "final")]
     pub final_: bool,
-    #[doc = "The type of this event, used as a discriminator. Always 'status-update'."]
-    pub kind: ::std::string::String,
-    #[doc = "Optional metadata for extensions."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+    #[doc = "Optional metadata to associate with the task update."]
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub metadata: ::std::option::Option<Struct>,
     #[doc = "The new status of the task."]
     pub status: TaskStatus,
-    #[doc = "The ID of the task that was updated."]
+    #[doc = "The id of the task that is changed"]
     #[serde(rename = "taskId")]
     pub task_id: ::std::string::String,
-}
-impl ::std::convert::From<&TaskStatusUpdateEvent> for TaskStatusUpdateEvent {
-    fn from(value: &TaskStatusUpdateEvent) -> Self {
-        value.clone()
-    }
 }
 impl TaskStatusUpdateEvent {
     pub fn builder() -> builder::TaskStatusUpdateEvent {
         Default::default()
     }
 }
-#[doc = "Represents a text segment within a message or artifact."]
+#[doc = "`Timestamp`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
 #[doc = r" ```json"]
 #[doc = "{"]
-#[doc = "  \"description\": \"Represents a text segment within a message or artifact.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"kind\","]
-#[doc = "    \"text\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"kind\": {"]
-#[doc = "      \"description\": \"The type of this part, used as a discriminator. Always 'text'.\","]
-#[doc = "      \"type\": \"string\","]
-#[doc = "      \"const\": \"text\""]
-#[doc = "    },"]
-#[doc = "    \"metadata\": {"]
-#[doc = "      \"description\": \"Optional metadata associated with this part.\","]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"additionalProperties\": {}"]
-#[doc = "    },"]
-#[doc = "    \"text\": {"]
-#[doc = "      \"description\": \"The string content of the text part.\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct TextPart {
-    #[doc = "The type of this part, used as a discriminator. Always 'text'."]
-    pub kind: ::std::string::String,
-    #[doc = "Optional metadata associated with this part."]
-    #[serde(default, skip_serializing_if = "::serde_json::Map::is_empty")]
-    pub metadata: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-    #[doc = "The string content of the text part."]
-    pub text: ::std::string::String,
-}
-impl ::std::convert::From<&TextPart> for TextPart {
-    fn from(value: &TextPart) -> Self {
-        value.clone()
-    }
-}
-impl TextPart {
-    pub fn builder() -> builder::TextPart {
-        Default::default()
-    }
-}
-#[doc = "Supported A2A transport protocols."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Supported A2A transport protocols.\","]
+#[doc = "  \"title\": \"Timestamp\","]
 #[doc = "  \"type\": \"string\","]
-#[doc = "  \"enum\": ["]
-#[doc = "    \"JSONRPC\","]
-#[doc = "    \"GRPC\","]
-#[doc = "    \"HTTP+JSON\""]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(
-    :: serde :: Deserialize,
-    :: serde :: Serialize,
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-)]
-pub enum TransportProtocol {
-    #[serde(rename = "JSONRPC")]
-    Jsonrpc,
-    #[serde(rename = "GRPC")]
-    Grpc,
-    #[serde(rename = "HTTP+JSON")]
-    HttpJson,
-}
-impl ::std::convert::From<&Self> for TransportProtocol {
-    fn from(value: &TransportProtocol) -> Self {
-        value.clone()
-    }
-}
-impl ::std::fmt::Display for TransportProtocol {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match *self {
-            Self::Jsonrpc => write!(f, "JSONRPC"),
-            Self::Grpc => write!(f, "GRPC"),
-            Self::HttpJson => write!(f, "HTTP+JSON"),
-        }
-    }
-}
-impl ::std::str::FromStr for TransportProtocol {
-    type Err = self::error::ConversionError;
-    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        match value {
-            "JSONRPC" => Ok(Self::Jsonrpc),
-            "GRPC" => Ok(Self::Grpc),
-            "HTTP+JSON" => Ok(Self::HttpJson),
-            _ => Err("invalid value".into()),
-        }
-    }
-}
-impl ::std::convert::TryFrom<&str> for TransportProtocol {
-    type Error = self::error::ConversionError;
-    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<&::std::string::String> for TransportProtocol {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: &::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-impl ::std::convert::TryFrom<::std::string::String> for TransportProtocol {
-    type Error = self::error::ConversionError;
-    fn try_from(
-        value: ::std::string::String,
-    ) -> ::std::result::Result<Self, self::error::ConversionError> {
-        value.parse()
-    }
-}
-#[doc = "An A2A-specific error indicating that the requested operation is not supported by the agent."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"An A2A-specific error indicating that the requested operation is not supported by the agent.\","]
-#[doc = "  \"type\": \"object\","]
-#[doc = "  \"required\": ["]
-#[doc = "    \"code\","]
-#[doc = "    \"message\""]
-#[doc = "  ],"]
-#[doc = "  \"properties\": {"]
-#[doc = "    \"code\": {"]
-#[doc = "      \"description\": \"The error code for an unsupported operation.\","]
-#[doc = "      \"type\": \"integer\","]
-#[doc = "      \"const\": -32004"]
-#[doc = "    },"]
-#[doc = "    \"data\": {"]
-#[doc = "      \"description\": \"A primitive or structured value containing additional information about the error.\\nThis may be omitted.\""]
-#[doc = "    },"]
-#[doc = "    \"message\": {"]
-#[doc = "      \"description\": \"The error message.\","]
-#[doc = "      \"default\": \"This operation is not supported\","]
-#[doc = "      \"type\": \"string\""]
-#[doc = "    }"]
-#[doc = "  }"]
+#[doc = "  \"format\": \"date-time\","]
+#[doc = "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-pub struct UnsupportedOperationError {
-    #[doc = "The error code for an unsupported operation."]
-    pub code: i64,
-    #[doc = "A primitive or structured value containing additional information about the error.\nThis may be omitted."]
-    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub data: ::std::option::Option<::serde_json::Value>,
-    #[doc = "The error message."]
-    pub message: ::std::string::String,
-}
-impl ::std::convert::From<&UnsupportedOperationError> for UnsupportedOperationError {
-    fn from(value: &UnsupportedOperationError) -> Self {
-        value.clone()
+#[serde(transparent)]
+pub struct Timestamp(pub ::chrono::DateTime<::chrono::offset::Utc>);
+impl ::std::ops::Deref for Timestamp {
+    type Target = ::chrono::DateTime<::chrono::offset::Utc>;
+    fn deref(&self) -> &::chrono::DateTime<::chrono::offset::Utc> {
+        &self.0
     }
 }
-impl UnsupportedOperationError {
-    pub fn builder() -> builder::UnsupportedOperationError {
-        Default::default()
+impl ::std::convert::From<Timestamp> for ::chrono::DateTime<::chrono::offset::Utc> {
+    fn from(value: Timestamp) -> Self {
+        value.0
+    }
+}
+impl ::std::convert::From<::chrono::DateTime<::chrono::offset::Utc>> for Timestamp {
+    fn from(value: ::chrono::DateTime<::chrono::offset::Utc>) -> Self {
+        Self(value)
+    }
+}
+impl ::std::str::FromStr for Timestamp {
+    type Err = <::chrono::DateTime<::chrono::offset::Utc> as ::std::str::FromStr>::Err;
+    fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
+        Ok(Self(value.parse()?))
+    }
+}
+impl ::std::convert::TryFrom<&str> for Timestamp {
+    type Error = <::chrono::DateTime<::chrono::offset::Utc> as ::std::str::FromStr>::Err;
+    fn try_from(value: &str) -> ::std::result::Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<String> for Timestamp {
+    type Error = <::chrono::DateTime<::chrono::offset::Utc> as ::std::str::FromStr>::Err;
+    fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+impl ::std::fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 #[doc = r" Types for composing complex structures."]
 pub mod builder {
-    #[derive(Clone, Debug)]
-    pub struct A2aError {
-        subtype_0: ::std::result::Result<
-            ::std::option::Option<super::JsonParseError>,
-            ::std::string::String,
-        >,
-        subtype_1: ::std::result::Result<
-            ::std::option::Option<super::InvalidRequestError>,
-            ::std::string::String,
-        >,
-        subtype_2: ::std::result::Result<
-            ::std::option::Option<super::MethodNotFoundError>,
-            ::std::string::String,
-        >,
-        subtype_3: ::std::result::Result<
-            ::std::option::Option<super::InvalidParamsError>,
-            ::std::string::String,
-        >,
-        subtype_4: ::std::result::Result<
-            ::std::option::Option<super::InternalError>,
-            ::std::string::String,
-        >,
-        subtype_5: ::std::result::Result<
-            ::std::option::Option<super::TaskNotFoundError>,
-            ::std::string::String,
-        >,
-        subtype_6: ::std::result::Result<
-            ::std::option::Option<super::TaskNotCancelableError>,
-            ::std::string::String,
-        >,
-        subtype_7: ::std::result::Result<
-            ::std::option::Option<super::PushNotificationNotSupportedError>,
-            ::std::string::String,
-        >,
-        subtype_8: ::std::result::Result<
-            ::std::option::Option<super::UnsupportedOperationError>,
-            ::std::string::String,
-        >,
-        subtype_9: ::std::result::Result<
-            ::std::option::Option<super::ContentTypeNotSupportedError>,
-            ::std::string::String,
-        >,
-        subtype_10: ::std::result::Result<
-            ::std::option::Option<super::InvalidAgentResponseError>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for A2aError {
-        fn default() -> Self {
-            Self {
-                subtype_0: Ok(Default::default()),
-                subtype_1: Ok(Default::default()),
-                subtype_2: Ok(Default::default()),
-                subtype_3: Ok(Default::default()),
-                subtype_4: Ok(Default::default()),
-                subtype_5: Ok(Default::default()),
-                subtype_6: Ok(Default::default()),
-                subtype_7: Ok(Default::default()),
-                subtype_8: Ok(Default::default()),
-                subtype_9: Ok(Default::default()),
-                subtype_10: Ok(Default::default()),
-            }
-        }
-    }
-    impl A2aError {
-        pub fn subtype_0<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::JsonParseError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_0 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_0: {}", e));
-            self
-        }
-        pub fn subtype_1<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InvalidRequestError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_1 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_1: {}", e));
-            self
-        }
-        pub fn subtype_2<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::MethodNotFoundError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_2 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_2: {}", e));
-            self
-        }
-        pub fn subtype_3<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InvalidParamsError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_3 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_3: {}", e));
-            self
-        }
-        pub fn subtype_4<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InternalError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_4 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_4: {}", e));
-            self
-        }
-        pub fn subtype_5<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::TaskNotFoundError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_5 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_5: {}", e));
-            self
-        }
-        pub fn subtype_6<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::TaskNotCancelableError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_6 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_6: {}", e));
-            self
-        }
-        pub fn subtype_7<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::PushNotificationNotSupportedError>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_7 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_7: {}", e));
-            self
-        }
-        pub fn subtype_8<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::UnsupportedOperationError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_8 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_8: {}", e));
-            self
-        }
-        pub fn subtype_9<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::ContentTypeNotSupportedError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_9 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_9: {}", e));
-            self
-        }
-        pub fn subtype_10<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InvalidAgentResponseError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_10 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_10: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<A2aError> for super::A2aError {
-        type Error = super::error::ConversionError;
-        fn try_from(value: A2aError) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                subtype_0: value.subtype_0?,
-                subtype_1: value.subtype_1?,
-                subtype_2: value.subtype_2?,
-                subtype_3: value.subtype_3?,
-                subtype_4: value.subtype_4?,
-                subtype_5: value.subtype_5?,
-                subtype_6: value.subtype_6?,
-                subtype_7: value.subtype_7?,
-                subtype_8: value.subtype_8?,
-                subtype_9: value.subtype_9?,
-                subtype_10: value.subtype_10?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::A2aError> for A2aError {
-        fn from(value: super::A2aError) -> Self {
-            Self {
-                subtype_0: Ok(value.subtype_0),
-                subtype_1: Ok(value.subtype_1),
-                subtype_2: Ok(value.subtype_2),
-                subtype_3: Ok(value.subtype_3),
-                subtype_4: Ok(value.subtype_4),
-                subtype_5: Ok(value.subtype_5),
-                subtype_6: Ok(value.subtype_6),
-                subtype_7: Ok(value.subtype_7),
-                subtype_8: Ok(value.subtype_8),
-                subtype_9: Ok(value.subtype_9),
-                subtype_10: Ok(value.subtype_10),
-            }
-        }
-    }
     #[derive(Clone, Debug)]
     pub struct AgentCapabilities {
         extensions:
@@ -7264,7 +3318,7 @@ pub mod builder {
         {
             self.extensions = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extensions: {}", e));
+                .map_err(|e| format!("error converting supplied value for extensions: {e}"));
             self
         }
         pub fn push_notifications<T>(mut self, value: T) -> Self
@@ -7273,10 +3327,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.push_notifications = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for push_notifications: {}",
-                    e
-                )
+                format!("error converting supplied value for push_notifications: {e}")
             });
             self
         }
@@ -7286,10 +3337,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.state_transition_history = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for state_transition_history: {}",
-                    e
-                )
+                format!("error converting supplied value for state_transition_history: {e}")
             });
             self
         }
@@ -7300,7 +3348,7 @@ pub mod builder {
         {
             self.streaming = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for streaming: {}", e));
+                .map_err(|e| format!("error converting supplied value for streaming: {e}"));
             self
         }
     }
@@ -7346,21 +3394,16 @@ pub mod builder {
             ::std::string::String,
         >,
         name: ::std::result::Result<::std::string::String, ::std::string::String>,
-        preferred_transport: ::std::result::Result<::std::string::String, ::std::string::String>,
+        preferred_transport: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
         protocol_version: ::std::result::Result<::std::string::String, ::std::string::String>,
         provider: ::std::result::Result<
             ::std::option::Option<super::AgentProvider>,
             ::std::string::String,
         >,
-        security: ::std::result::Result<
-            ::std::vec::Vec<
-                ::std::collections::HashMap<
-                    ::std::string::String,
-                    ::std::vec::Vec<::std::string::String>,
-                >,
-            >,
-            ::std::string::String,
-        >,
+        security: ::std::result::Result<::std::vec::Vec<super::Security>, ::std::string::String>,
         security_schemes: ::std::result::Result<
             ::std::collections::HashMap<::std::string::String, super::SecurityScheme>,
             ::std::string::String,
@@ -7370,9 +3413,14 @@ pub mod builder {
             ::std::string::String,
         >,
         skills: ::std::result::Result<::std::vec::Vec<super::AgentSkill>, ::std::string::String>,
-        supports_authenticated_extended_card:
+        supported_interfaces:
+            ::std::result::Result<::std::vec::Vec<super::AgentInterface>, ::std::string::String>,
+        supports_extended_agent_card:
             ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
-        url: ::std::result::Result<::std::string::String, ::std::string::String>,
+        url: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
         version: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for AgentCard {
@@ -7386,15 +3434,16 @@ pub mod builder {
                 documentation_url: Ok(Default::default()),
                 icon_url: Ok(Default::default()),
                 name: Err("no value supplied for name".to_string()),
-                preferred_transport: Ok(super::defaults::agent_card_preferred_transport()),
+                preferred_transport: Ok(Default::default()),
                 protocol_version: Err("no value supplied for protocol_version".to_string()),
                 provider: Ok(Default::default()),
                 security: Ok(Default::default()),
                 security_schemes: Ok(Default::default()),
                 signatures: Ok(Default::default()),
                 skills: Err("no value supplied for skills".to_string()),
-                supports_authenticated_extended_card: Ok(Default::default()),
-                url: Err("no value supplied for url".to_string()),
+                supported_interfaces: Ok(Default::default()),
+                supports_extended_agent_card: Ok(Default::default()),
+                url: Ok(Default::default()),
                 version: Err("no value supplied for version".to_string()),
             }
         }
@@ -7406,10 +3455,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.additional_interfaces = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for additional_interfaces: {}",
-                    e
-                )
+                format!("error converting supplied value for additional_interfaces: {e}")
             });
             self
         }
@@ -7420,7 +3466,7 @@ pub mod builder {
         {
             self.capabilities = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for capabilities: {}", e));
+                .map_err(|e| format!("error converting supplied value for capabilities: {e}"));
             self
         }
         pub fn default_input_modes<T>(mut self, value: T) -> Self
@@ -7429,10 +3475,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.default_input_modes = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for default_input_modes: {}",
-                    e
-                )
+                format!("error converting supplied value for default_input_modes: {e}")
             });
             self
         }
@@ -7442,10 +3485,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.default_output_modes = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for default_output_modes: {}",
-                    e
-                )
+                format!("error converting supplied value for default_output_modes: {e}")
             });
             self
         }
@@ -7456,7 +3496,7 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn documentation_url<T>(mut self, value: T) -> Self
@@ -7464,12 +3504,9 @@ pub mod builder {
             T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
             T::Error: ::std::fmt::Display,
         {
-            self.documentation_url = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for documentation_url: {}",
-                    e
-                )
-            });
+            self.documentation_url = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for documentation_url: {e}"));
             self
         }
         pub fn icon_url<T>(mut self, value: T) -> Self
@@ -7479,7 +3516,7 @@ pub mod builder {
         {
             self.icon_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for icon_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for icon_url: {e}"));
             self
         }
         pub fn name<T>(mut self, value: T) -> Self
@@ -7489,19 +3526,16 @@ pub mod builder {
         {
             self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
         pub fn preferred_transport<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::string::String>,
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
             T::Error: ::std::fmt::Display,
         {
             self.preferred_transport = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for preferred_transport: {}",
-                    e
-                )
+                format!("error converting supplied value for preferred_transport: {e}")
             });
             self
         }
@@ -7510,12 +3544,9 @@ pub mod builder {
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.protocol_version = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for protocol_version: {}",
-                    e
-                )
-            });
+            self.protocol_version = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for protocol_version: {e}"));
             self
         }
         pub fn provider<T>(mut self, value: T) -> Self
@@ -7525,24 +3556,17 @@ pub mod builder {
         {
             self.provider = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for provider: {}", e));
+                .map_err(|e| format!("error converting supplied value for provider: {e}"));
             self
         }
         pub fn security<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::std::vec::Vec<
-                        ::std::collections::HashMap<
-                            ::std::string::String,
-                            ::std::vec::Vec<::std::string::String>,
-                        >,
-                    >,
-                >,
+            T: ::std::convert::TryInto<::std::vec::Vec<super::Security>>,
             T::Error: ::std::fmt::Display,
         {
             self.security = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for security: {}", e));
+                .map_err(|e| format!("error converting supplied value for security: {e}"));
             self
         }
         pub fn security_schemes<T>(mut self, value: T) -> Self
@@ -7552,12 +3576,9 @@ pub mod builder {
                 >,
             T::Error: ::std::fmt::Display,
         {
-            self.security_schemes = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for security_schemes: {}",
-                    e
-                )
-            });
+            self.security_schemes = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for security_schemes: {e}"));
             self
         }
         pub fn signatures<T>(mut self, value: T) -> Self
@@ -7567,7 +3588,7 @@ pub mod builder {
         {
             self.signatures = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for signatures: {}", e));
+                .map_err(|e| format!("error converting supplied value for signatures: {e}"));
             self
         }
         pub fn skills<T>(mut self, value: T) -> Self
@@ -7577,30 +3598,37 @@ pub mod builder {
         {
             self.skills = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for skills: {}", e));
+                .map_err(|e| format!("error converting supplied value for skills: {e}"));
             self
         }
-        pub fn supports_authenticated_extended_card<T>(mut self, value: T) -> Self
+        pub fn supported_interfaces<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<super::AgentInterface>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.supported_interfaces = value.try_into().map_err(|e| {
+                format!("error converting supplied value for supported_interfaces: {e}")
+            });
+            self
+        }
+        pub fn supports_extended_agent_card<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::option::Option<bool>>,
             T::Error: ::std::fmt::Display,
         {
-            self.supports_authenticated_extended_card = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for supports_authenticated_extended_card: {}",
-                    e
-                )
+            self.supports_extended_agent_card = value.try_into().map_err(|e| {
+                format!("error converting supplied value for supports_extended_agent_card: {e}")
             });
             self
         }
         pub fn url<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::string::String>,
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
             T::Error: ::std::fmt::Display,
         {
             self.url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for url: {}", e));
+                .map_err(|e| format!("error converting supplied value for url: {e}"));
             self
         }
         pub fn version<T>(mut self, value: T) -> Self
@@ -7610,7 +3638,7 @@ pub mod builder {
         {
             self.version = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for version: {}", e));
+                .map_err(|e| format!("error converting supplied value for version: {e}"));
             self
         }
     }
@@ -7635,7 +3663,8 @@ pub mod builder {
                 security_schemes: value.security_schemes?,
                 signatures: value.signatures?,
                 skills: value.skills?,
-                supports_authenticated_extended_card: value.supports_authenticated_extended_card?,
+                supported_interfaces: value.supported_interfaces?,
+                supports_extended_agent_card: value.supports_extended_agent_card?,
                 url: value.url?,
                 version: value.version?,
             })
@@ -7659,7 +3688,8 @@ pub mod builder {
                 security_schemes: Ok(value.security_schemes),
                 signatures: Ok(value.signatures),
                 skills: Ok(value.skills),
-                supports_authenticated_extended_card: Ok(value.supports_authenticated_extended_card),
+                supported_interfaces: Ok(value.supported_interfaces),
+                supports_extended_agent_card: Ok(value.supports_extended_agent_card),
                 url: Ok(value.url),
                 version: Ok(value.version),
             }
@@ -7667,10 +3697,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct AgentCardSignature {
-        header: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        header: ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
         protected: ::std::result::Result<::std::string::String, ::std::string::String>,
         signature: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
@@ -7686,14 +3713,12 @@ pub mod builder {
     impl AgentCardSignature {
         pub fn header<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.header = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for header: {}", e));
+                .map_err(|e| format!("error converting supplied value for header: {e}"));
             self
         }
         pub fn protected<T>(mut self, value: T) -> Self
@@ -7703,7 +3728,7 @@ pub mod builder {
         {
             self.protected = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for protected: {}", e));
+                .map_err(|e| format!("error converting supplied value for protected: {e}"));
             self
         }
         pub fn signature<T>(mut self, value: T) -> Self
@@ -7713,7 +3738,7 @@ pub mod builder {
         {
             self.signature = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for signature: {}", e));
+                .map_err(|e| format!("error converting supplied value for signature: {e}"));
             self
         }
     }
@@ -7740,23 +3765,17 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct AgentExtension {
-        description: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-        params: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-        required: ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
+        description: ::std::result::Result<::std::string::String, ::std::string::String>,
+        params: ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
+        required: ::std::result::Result<bool, ::std::string::String>,
         uri: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for AgentExtension {
         fn default() -> Self {
             Self {
-                description: Ok(Default::default()),
+                description: Err("no value supplied for description".to_string()),
                 params: Ok(Default::default()),
-                required: Ok(Default::default()),
+                required: Err("no value supplied for required".to_string()),
                 uri: Err("no value supplied for uri".to_string()),
             }
         }
@@ -7764,34 +3783,32 @@ pub mod builder {
     impl AgentExtension {
         pub fn description<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn params<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.params = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for params: {e}"));
             self
         }
         pub fn required<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::option::Option<bool>>,
+            T: ::std::convert::TryInto<bool>,
             T::Error: ::std::fmt::Display,
         {
             self.required = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for required: {}", e));
+                .map_err(|e| format!("error converting supplied value for required: {e}"));
             self
         }
         pub fn uri<T>(mut self, value: T) -> Self
@@ -7801,7 +3818,7 @@ pub mod builder {
         {
             self.uri = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for uri: {}", e));
+                .map_err(|e| format!("error converting supplied value for uri: {e}"));
             self
         }
     }
@@ -7830,26 +3847,41 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct AgentInterface {
-        transport: ::std::result::Result<::std::string::String, ::std::string::String>,
+        protocol_binding: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
         url: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for AgentInterface {
         fn default() -> Self {
             Self {
-                transport: Err("no value supplied for transport".to_string()),
+                protocol_binding: Err("no value supplied for protocol_binding".to_string()),
+                tenant: Ok(Default::default()),
                 url: Err("no value supplied for url".to_string()),
             }
         }
     }
     impl AgentInterface {
-        pub fn transport<T>(mut self, value: T) -> Self
+        pub fn protocol_binding<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.transport = value
+            self.protocol_binding = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for transport: {}", e));
+                .map_err(|e| format!("error converting supplied value for protocol_binding: {e}"));
+            self
+        }
+        pub fn tenant<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.tenant = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
         pub fn url<T>(mut self, value: T) -> Self
@@ -7859,7 +3891,7 @@ pub mod builder {
         {
             self.url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for url: {}", e));
+                .map_err(|e| format!("error converting supplied value for url: {e}"));
             self
         }
     }
@@ -7869,7 +3901,8 @@ pub mod builder {
             value: AgentInterface,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                transport: value.transport?,
+                protocol_binding: value.protocol_binding?,
+                tenant: value.tenant?,
                 url: value.url?,
             })
         }
@@ -7877,7 +3910,8 @@ pub mod builder {
     impl ::std::convert::From<super::AgentInterface> for AgentInterface {
         fn from(value: super::AgentInterface) -> Self {
             Self {
-                transport: Ok(value.transport),
+                protocol_binding: Ok(value.protocol_binding),
+                tenant: Ok(value.tenant),
                 url: Ok(value.url),
             }
         }
@@ -7903,7 +3937,7 @@ pub mod builder {
         {
             self.organization = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for organization: {}", e));
+                .map_err(|e| format!("error converting supplied value for organization: {e}"));
             self
         }
         pub fn url<T>(mut self, value: T) -> Self
@@ -7913,7 +3947,7 @@ pub mod builder {
         {
             self.url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for url: {}", e));
+                .map_err(|e| format!("error converting supplied value for url: {e}"));
             self
         }
     }
@@ -7947,6 +3981,7 @@ pub mod builder {
         name: ::std::result::Result<::std::string::String, ::std::string::String>,
         output_modes:
             ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
+        security: ::std::result::Result<::std::vec::Vec<super::Security>, ::std::string::String>,
         tags: ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
     }
     impl ::std::default::Default for AgentSkill {
@@ -7958,6 +3993,7 @@ pub mod builder {
                 input_modes: Ok(Default::default()),
                 name: Err("no value supplied for name".to_string()),
                 output_modes: Ok(Default::default()),
+                security: Ok(Default::default()),
                 tags: Err("no value supplied for tags".to_string()),
             }
         }
@@ -7970,7 +4006,7 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn examples<T>(mut self, value: T) -> Self
@@ -7980,7 +4016,7 @@ pub mod builder {
         {
             self.examples = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for examples: {}", e));
+                .map_err(|e| format!("error converting supplied value for examples: {e}"));
             self
         }
         pub fn id<T>(mut self, value: T) -> Self
@@ -7990,7 +4026,7 @@ pub mod builder {
         {
             self.id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for id: {e}"));
             self
         }
         pub fn input_modes<T>(mut self, value: T) -> Self
@@ -8000,7 +4036,7 @@ pub mod builder {
         {
             self.input_modes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for input_modes: {}", e));
+                .map_err(|e| format!("error converting supplied value for input_modes: {e}"));
             self
         }
         pub fn name<T>(mut self, value: T) -> Self
@@ -8010,7 +4046,7 @@ pub mod builder {
         {
             self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
         pub fn output_modes<T>(mut self, value: T) -> Self
@@ -8020,7 +4056,17 @@ pub mod builder {
         {
             self.output_modes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for output_modes: {}", e));
+                .map_err(|e| format!("error converting supplied value for output_modes: {e}"));
+            self
+        }
+        pub fn security<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<super::Security>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.security = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for security: {e}"));
             self
         }
         pub fn tags<T>(mut self, value: T) -> Self
@@ -8030,7 +4076,7 @@ pub mod builder {
         {
             self.tags = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for tags: {}", e));
+                .map_err(|e| format!("error converting supplied value for tags: {e}"));
             self
         }
     }
@@ -8046,6 +4092,7 @@ pub mod builder {
                 input_modes: value.input_modes?,
                 name: value.name?,
                 output_modes: value.output_modes?,
+                security: value.security?,
                 tags: value.tags?,
             })
         }
@@ -8059,6 +4106,7 @@ pub mod builder {
                 input_modes: Ok(value.input_modes),
                 name: Ok(value.name),
                 output_modes: Ok(value.output_modes),
+                security: Ok(value.security),
                 tags: Ok(value.tags),
             }
         }
@@ -8069,17 +4117,15 @@ pub mod builder {
             ::std::option::Option<::std::string::String>,
             ::std::string::String,
         >,
-        in_: ::std::result::Result<super::ApiKeySecuritySchemeIn, ::std::string::String>,
+        location: ::std::result::Result<::std::string::String, ::std::string::String>,
         name: ::std::result::Result<::std::string::String, ::std::string::String>,
-        type_: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for ApiKeySecurityScheme {
         fn default() -> Self {
             Self {
                 description: Ok(Default::default()),
-                in_: Err("no value supplied for in_".to_string()),
+                location: Err("no value supplied for location".to_string()),
                 name: Err("no value supplied for name".to_string()),
-                type_: Err("no value supplied for type_".to_string()),
             }
         }
     }
@@ -8091,17 +4137,17 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
-        pub fn in_<T>(mut self, value: T) -> Self
+        pub fn location<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::ApiKeySecuritySchemeIn>,
+            T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.in_ = value
+            self.location = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for in_: {}", e));
+                .map_err(|e| format!("error converting supplied value for location: {e}"));
             self
         }
         pub fn name<T>(mut self, value: T) -> Self
@@ -8111,17 +4157,7 @@ pub mod builder {
         {
             self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
-            self
-        }
-        pub fn type_<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.type_ = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
     }
@@ -8132,9 +4168,8 @@ pub mod builder {
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
                 description: value.description?,
-                in_: value.in_?,
+                location: value.location?,
                 name: value.name?,
-                type_: value.type_?,
             })
         }
     }
@@ -8142,9 +4177,8 @@ pub mod builder {
         fn from(value: super::ApiKeySecurityScheme) -> Self {
             Self {
                 description: Ok(value.description),
-                in_: Ok(value.in_),
+                location: Ok(value.location),
                 name: Ok(value.name),
-                type_: Ok(value.type_),
             }
         }
     }
@@ -8157,10 +4191,8 @@ pub mod builder {
         >,
         extensions:
             ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
         name: ::std::result::Result<
             ::std::option::Option<::std::string::String>,
             ::std::string::String,
@@ -8187,7 +4219,7 @@ pub mod builder {
         {
             self.artifact_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for artifact_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for artifact_id: {e}"));
             self
         }
         pub fn description<T>(mut self, value: T) -> Self
@@ -8197,7 +4229,7 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn extensions<T>(mut self, value: T) -> Self
@@ -8207,19 +4239,17 @@ pub mod builder {
         {
             self.extensions = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extensions: {}", e));
+                .map_err(|e| format!("error converting supplied value for extensions: {e}"));
             self
         }
         pub fn metadata<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.metadata = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
             self
         }
         pub fn name<T>(mut self, value: T) -> Self
@@ -8229,7 +4259,7 @@ pub mod builder {
         {
             self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
         pub fn parts<T>(mut self, value: T) -> Self
@@ -8239,7 +4269,7 @@ pub mod builder {
         {
             self.parts = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for parts: {}", e));
+                .map_err(|e| format!("error converting supplied value for parts: {e}"));
             self
         }
     }
@@ -8265,6 +4295,64 @@ pub mod builder {
                 metadata: Ok(value.metadata),
                 name: Ok(value.name),
                 parts: Ok(value.parts),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct AuthenticationInfo {
+        credentials: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
+        schemes:
+            ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
+    }
+    impl ::std::default::Default for AuthenticationInfo {
+        fn default() -> Self {
+            Self {
+                credentials: Ok(Default::default()),
+                schemes: Err("no value supplied for schemes".to_string()),
+            }
+        }
+    }
+    impl AuthenticationInfo {
+        pub fn credentials<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.credentials = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for credentials: {e}"));
+            self
+        }
+        pub fn schemes<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.schemes = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for schemes: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<AuthenticationInfo> for super::AuthenticationInfo {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: AuthenticationInfo,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                credentials: value.credentials?,
+                schemes: value.schemes?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::AuthenticationInfo> for AuthenticationInfo {
+        fn from(value: super::AuthenticationInfo) -> Self {
+            Self {
+                credentials: Ok(value.credentials),
+                schemes: Ok(value.schemes),
             }
         }
     }
@@ -8297,12 +4385,9 @@ pub mod builder {
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.authorization_url = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for authorization_url: {}",
-                    e
-                )
-            });
+            self.authorization_url = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for authorization_url: {e}"));
             self
         }
         pub fn refresh_url<T>(mut self, value: T) -> Self
@@ -8312,7 +4397,7 @@ pub mod builder {
         {
             self.refresh_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for refresh_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for refresh_url: {e}"));
             self
         }
         pub fn scopes<T>(mut self, value: T) -> Self
@@ -8324,7 +4409,7 @@ pub mod builder {
         {
             self.scopes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for scopes: {}", e));
+                .map_err(|e| format!("error converting supplied value for scopes: {e}"));
             self
         }
         pub fn token_url<T>(mut self, value: T) -> Self
@@ -8334,7 +4419,7 @@ pub mod builder {
         {
             self.token_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for token_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for token_url: {e}"));
             self
         }
     }
@@ -8363,60 +4448,36 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct CancelTaskRequest {
-        id: ::std::result::Result<super::CancelTaskRequestId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<super::TaskIdParams, ::std::string::String>,
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for CancelTaskRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                name: Err("no value supplied for name".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
             }
         }
     }
     impl CancelTaskRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::CancelTaskRequestId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn name<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
-        pub fn method<T>(mut self, value: T) -> Self
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.method = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::TaskIdParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -8426,88 +4487,16 @@ pub mod builder {
             value: CancelTaskRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                name: value.name?,
+                tenant: value.tenant?,
             })
         }
     }
     impl ::std::convert::From<super::CancelTaskRequest> for CancelTaskRequest {
         fn from(value: super::CancelTaskRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct CancelTaskSuccessResponse {
-        id: ::std::result::Result<super::CancelTaskSuccessResponseId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<super::Task, ::std::string::String>,
-    }
-    impl ::std::default::Default for CancelTaskSuccessResponse {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
-            }
-        }
-    }
-    impl CancelTaskSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::CancelTaskSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::Task>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<CancelTaskSuccessResponse> for super::CancelTaskSuccessResponse {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: CancelTaskSuccessResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::CancelTaskSuccessResponse> for CancelTaskSuccessResponse {
-        fn from(value: super::CancelTaskSuccessResponse) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
+                name: Ok(value.name),
+                tenant: Ok(value.tenant),
             }
         }
     }
@@ -8540,7 +4529,7 @@ pub mod builder {
         {
             self.refresh_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for refresh_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for refresh_url: {e}"));
             self
         }
         pub fn scopes<T>(mut self, value: T) -> Self
@@ -8552,7 +4541,7 @@ pub mod builder {
         {
             self.scopes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for scopes: {}", e));
+                .map_err(|e| format!("error converting supplied value for scopes: {e}"));
             self
         }
         pub fn token_url<T>(mut self, value: T) -> Self
@@ -8562,7 +4551,7 @@ pub mod builder {
         {
             self.token_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for token_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for token_url: {e}"));
             self
         }
     }
@@ -8588,297 +4577,73 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    pub struct ContentTypeNotSupportedError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for ContentTypeNotSupportedError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl ContentTypeNotSupportedError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<ContentTypeNotSupportedError> for super::ContentTypeNotSupportedError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: ContentTypeNotSupportedError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::ContentTypeNotSupportedError> for ContentTypeNotSupportedError {
-        fn from(value: super::ContentTypeNotSupportedError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
     pub struct DataPart {
-        data: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        data: ::std::result::Result<super::Struct, ::std::string::String>,
     }
     impl ::std::default::Default for DataPart {
         fn default() -> Self {
             Self {
                 data: Err("no value supplied for data".to_string()),
-                kind: Err("no value supplied for kind".to_string()),
-                metadata: Ok(Default::default()),
             }
         }
     }
     impl DataPart {
         pub fn data<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<super::Struct>,
             T::Error: ::std::fmt::Display,
         {
             self.data = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn kind<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.kind = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for data: {e}"));
             self
         }
     }
     impl ::std::convert::TryFrom<DataPart> for super::DataPart {
         type Error = super::error::ConversionError;
         fn try_from(value: DataPart) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                data: value.data?,
-                kind: value.kind?,
-                metadata: value.metadata?,
-            })
+            Ok(Self { data: value.data? })
         }
     }
     impl ::std::convert::From<super::DataPart> for DataPart {
         fn from(value: super::DataPart) -> Self {
             Self {
                 data: Ok(value.data),
-                kind: Ok(value.kind),
-                metadata: Ok(value.metadata),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct DeleteTaskPushNotificationConfigParams {
-        id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-        push_notification_config_id:
-            ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for DeleteTaskPushNotificationConfigParams {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                metadata: Ok(Default::default()),
-                push_notification_config_id: Err(
-                    "no value supplied for push_notification_config_id".to_string(),
-                ),
-            }
-        }
-    }
-    impl DeleteTaskPushNotificationConfigParams {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-        pub fn push_notification_config_id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.push_notification_config_id = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for push_notification_config_id: {}",
-                    e
-                )
-            });
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<DeleteTaskPushNotificationConfigParams>
-        for super::DeleteTaskPushNotificationConfigParams
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: DeleteTaskPushNotificationConfigParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                metadata: value.metadata?,
-                push_notification_config_id: value.push_notification_config_id?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::DeleteTaskPushNotificationConfigParams>
-        for DeleteTaskPushNotificationConfigParams
-    {
-        fn from(value: super::DeleteTaskPushNotificationConfigParams) -> Self {
-            Self {
-                id: Ok(value.id),
-                metadata: Ok(value.metadata),
-                push_notification_config_id: Ok(value.push_notification_config_id),
             }
         }
     }
     #[derive(Clone, Debug)]
     pub struct DeleteTaskPushNotificationConfigRequest {
-        id: ::std::result::Result<
-            super::DeleteTaskPushNotificationConfigRequestId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<
-            super::DeleteTaskPushNotificationConfigParams,
-            ::std::string::String,
-        >,
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for DeleteTaskPushNotificationConfigRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                name: Err("no value supplied for name".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
             }
         }
     }
     impl DeleteTaskPushNotificationConfigRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::DeleteTaskPushNotificationConfigRequestId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn name<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
-        pub fn method<T>(mut self, value: T) -> Self
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.method = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::DeleteTaskPushNotificationConfigParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -8890,10 +4655,8 @@ pub mod builder {
             value: DeleteTaskPushNotificationConfigRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                name: value.name?,
+                tenant: value.tenant?,
             })
         }
     }
@@ -8902,195 +4665,73 @@ pub mod builder {
     {
         fn from(value: super::DeleteTaskPushNotificationConfigRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct DeleteTaskPushNotificationConfigSuccessResponse {
-        id: ::std::result::Result<
-            super::DeleteTaskPushNotificationConfigSuccessResponseId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<(), ::std::string::String>,
-    }
-    impl ::std::default::Default for DeleteTaskPushNotificationConfigSuccessResponse {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
-            }
-        }
-    }
-    impl DeleteTaskPushNotificationConfigSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::DeleteTaskPushNotificationConfigSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<()>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<DeleteTaskPushNotificationConfigSuccessResponse>
-        for super::DeleteTaskPushNotificationConfigSuccessResponse
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: DeleteTaskPushNotificationConfigSuccessResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::DeleteTaskPushNotificationConfigSuccessResponse>
-        for DeleteTaskPushNotificationConfigSuccessResponse
-    {
-        fn from(value: super::DeleteTaskPushNotificationConfigSuccessResponse) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct FileBase {
-        mime_type: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-        name: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for FileBase {
-        fn default() -> Self {
-            Self {
-                mime_type: Ok(Default::default()),
-                name: Ok(Default::default()),
-            }
-        }
-    }
-    impl FileBase {
-        pub fn mime_type<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.mime_type = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for mime_type: {}", e));
-            self
-        }
-        pub fn name<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.name = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<FileBase> for super::FileBase {
-        type Error = super::error::ConversionError;
-        fn try_from(value: FileBase) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                mime_type: value.mime_type?,
-                name: value.name?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::FileBase> for FileBase {
-        fn from(value: super::FileBase) -> Self {
-            Self {
-                mime_type: Ok(value.mime_type),
                 name: Ok(value.name),
+                tenant: Ok(value.tenant),
             }
         }
     }
     #[derive(Clone, Debug)]
     pub struct FilePart {
-        file: ::std::result::Result<super::FilePartFile, ::std::string::String>,
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+        file_with_bytes: ::std::result::Result<
+            ::std::option::Option<super::FilePartFileWithBytes>,
             ::std::string::String,
         >,
+        file_with_uri: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
+        media_type: ::std::result::Result<::std::string::String, ::std::string::String>,
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for FilePart {
         fn default() -> Self {
             Self {
-                file: Err("no value supplied for file".to_string()),
-                kind: Err("no value supplied for kind".to_string()),
-                metadata: Ok(Default::default()),
+                file_with_bytes: Ok(Default::default()),
+                file_with_uri: Ok(Default::default()),
+                media_type: Err("no value supplied for media_type".to_string()),
+                name: Err("no value supplied for name".to_string()),
             }
         }
     }
     impl FilePart {
-        pub fn file<T>(mut self, value: T) -> Self
+        pub fn file_with_bytes<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::FilePartFile>,
+            T: ::std::convert::TryInto<::std::option::Option<super::FilePartFileWithBytes>>,
             T::Error: ::std::fmt::Display,
         {
-            self.file = value
+            self.file_with_bytes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for file: {}", e));
+                .map_err(|e| format!("error converting supplied value for file_with_bytes: {e}"));
             self
         }
-        pub fn kind<T>(mut self, value: T) -> Self
+        pub fn file_with_uri<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.file_with_uri = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for file_with_uri: {e}"));
+            self
+        }
+        pub fn media_type<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.kind = value
+            self.media_type = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                .map_err(|e| format!("error converting supplied value for media_type: {e}"));
             self
         }
-        pub fn metadata<T>(mut self, value: T) -> Self
+        pub fn name<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.metadata = value
+            self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
     }
@@ -9098,314 +4739,95 @@ pub mod builder {
         type Error = super::error::ConversionError;
         fn try_from(value: FilePart) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                file: value.file?,
-                kind: value.kind?,
-                metadata: value.metadata?,
+                file_with_bytes: value.file_with_bytes?,
+                file_with_uri: value.file_with_uri?,
+                media_type: value.media_type?,
+                name: value.name?,
             })
         }
     }
     impl ::std::convert::From<super::FilePart> for FilePart {
         fn from(value: super::FilePart) -> Self {
             Self {
-                file: Ok(value.file),
-                kind: Ok(value.kind),
-                metadata: Ok(value.metadata),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct FileWithBytes {
-        bytes: ::std::result::Result<::std::string::String, ::std::string::String>,
-        mime_type: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-        name: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for FileWithBytes {
-        fn default() -> Self {
-            Self {
-                bytes: Err("no value supplied for bytes".to_string()),
-                mime_type: Ok(Default::default()),
-                name: Ok(Default::default()),
-            }
-        }
-    }
-    impl FileWithBytes {
-        pub fn bytes<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.bytes = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for bytes: {}", e));
-            self
-        }
-        pub fn mime_type<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.mime_type = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for mime_type: {}", e));
-            self
-        }
-        pub fn name<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.name = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<FileWithBytes> for super::FileWithBytes {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: FileWithBytes,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                bytes: value.bytes?,
-                mime_type: value.mime_type?,
-                name: value.name?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::FileWithBytes> for FileWithBytes {
-        fn from(value: super::FileWithBytes) -> Self {
-            Self {
-                bytes: Ok(value.bytes),
-                mime_type: Ok(value.mime_type),
+                file_with_bytes: Ok(value.file_with_bytes),
+                file_with_uri: Ok(value.file_with_uri),
+                media_type: Ok(value.media_type),
                 name: Ok(value.name),
             }
         }
     }
     #[derive(Clone, Debug)]
-    pub struct FileWithUri {
-        mime_type: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-        name: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-        uri: ::std::result::Result<::std::string::String, ::std::string::String>,
+    pub struct GetExtendedAgentCardRequest {
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
-    impl ::std::default::Default for FileWithUri {
+    impl ::std::default::Default for GetExtendedAgentCardRequest {
         fn default() -> Self {
             Self {
-                mime_type: Ok(Default::default()),
-                name: Ok(Default::default()),
-                uri: Err("no value supplied for uri".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
             }
         }
     }
-    impl FileWithUri {
-        pub fn mime_type<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.mime_type = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for mime_type: {}", e));
-            self
-        }
-        pub fn name<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.name = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for name: {}", e));
-            self
-        }
-        pub fn uri<T>(mut self, value: T) -> Self
+    impl GetExtendedAgentCardRequest {
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.uri = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for uri: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<FileWithUri> for super::FileWithUri {
+    impl ::std::convert::TryFrom<GetExtendedAgentCardRequest> for super::GetExtendedAgentCardRequest {
         type Error = super::error::ConversionError;
         fn try_from(
-            value: FileWithUri,
+            value: GetExtendedAgentCardRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                mime_type: value.mime_type?,
-                name: value.name?,
-                uri: value.uri?,
+                tenant: value.tenant?,
             })
         }
     }
-    impl ::std::convert::From<super::FileWithUri> for FileWithUri {
-        fn from(value: super::FileWithUri) -> Self {
+    impl ::std::convert::From<super::GetExtendedAgentCardRequest> for GetExtendedAgentCardRequest {
+        fn from(value: super::GetExtendedAgentCardRequest) -> Self {
             Self {
-                mime_type: Ok(value.mime_type),
-                name: Ok(value.name),
-                uri: Ok(value.uri),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct GetTaskPushNotificationConfigParams {
-        id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-        push_notification_config_id: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for GetTaskPushNotificationConfigParams {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                metadata: Ok(Default::default()),
-                push_notification_config_id: Ok(Default::default()),
-            }
-        }
-    }
-    impl GetTaskPushNotificationConfigParams {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-        pub fn push_notification_config_id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.push_notification_config_id = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for push_notification_config_id: {}",
-                    e
-                )
-            });
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<GetTaskPushNotificationConfigParams>
-        for super::GetTaskPushNotificationConfigParams
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: GetTaskPushNotificationConfigParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                metadata: value.metadata?,
-                push_notification_config_id: value.push_notification_config_id?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::GetTaskPushNotificationConfigParams>
-        for GetTaskPushNotificationConfigParams
-    {
-        fn from(value: super::GetTaskPushNotificationConfigParams) -> Self {
-            Self {
-                id: Ok(value.id),
-                metadata: Ok(value.metadata),
-                push_notification_config_id: Ok(value.push_notification_config_id),
+                tenant: Ok(value.tenant),
             }
         }
     }
     #[derive(Clone, Debug)]
     pub struct GetTaskPushNotificationConfigRequest {
-        id: ::std::result::Result<
-            super::GetTaskPushNotificationConfigRequestId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<
-            super::GetTaskPushNotificationConfigRequestParams,
-            ::std::string::String,
-        >,
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for GetTaskPushNotificationConfigRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                name: Err("no value supplied for name".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
             }
         }
     }
     impl GetTaskPushNotificationConfigRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::GetTaskPushNotificationConfigRequestId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn name<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
-        pub fn method<T>(mut self, value: T) -> Self
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.method = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::GetTaskPushNotificationConfigRequestParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -9417,10 +4839,8 @@ pub mod builder {
             value: GetTaskPushNotificationConfigRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                name: value.name?,
+                tenant: value.tenant?,
             })
         }
     }
@@ -9429,210 +4849,58 @@ pub mod builder {
     {
         fn from(value: super::GetTaskPushNotificationConfigRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct GetTaskPushNotificationConfigRequestParams {
-        subtype_0: ::std::result::Result<
-            ::std::option::Option<super::TaskIdParams>,
-            ::std::string::String,
-        >,
-        subtype_1: ::std::result::Result<
-            ::std::option::Option<super::GetTaskPushNotificationConfigParams>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for GetTaskPushNotificationConfigRequestParams {
-        fn default() -> Self {
-            Self {
-                subtype_0: Ok(Default::default()),
-                subtype_1: Ok(Default::default()),
-            }
-        }
-    }
-    impl GetTaskPushNotificationConfigRequestParams {
-        pub fn subtype_0<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::TaskIdParams>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_0 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_0: {}", e));
-            self
-        }
-        pub fn subtype_1<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::GetTaskPushNotificationConfigParams>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_1 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_1: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<GetTaskPushNotificationConfigRequestParams>
-        for super::GetTaskPushNotificationConfigRequestParams
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: GetTaskPushNotificationConfigRequestParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                subtype_0: value.subtype_0?,
-                subtype_1: value.subtype_1?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::GetTaskPushNotificationConfigRequestParams>
-        for GetTaskPushNotificationConfigRequestParams
-    {
-        fn from(value: super::GetTaskPushNotificationConfigRequestParams) -> Self {
-            Self {
-                subtype_0: Ok(value.subtype_0),
-                subtype_1: Ok(value.subtype_1),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct GetTaskPushNotificationConfigSuccessResponse {
-        id: ::std::result::Result<
-            super::GetTaskPushNotificationConfigSuccessResponseId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<super::TaskPushNotificationConfig, ::std::string::String>,
-    }
-    impl ::std::default::Default for GetTaskPushNotificationConfigSuccessResponse {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
-            }
-        }
-    }
-    impl GetTaskPushNotificationConfigSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::GetTaskPushNotificationConfigSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::TaskPushNotificationConfig>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<GetTaskPushNotificationConfigSuccessResponse>
-        for super::GetTaskPushNotificationConfigSuccessResponse
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: GetTaskPushNotificationConfigSuccessResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::GetTaskPushNotificationConfigSuccessResponse>
-        for GetTaskPushNotificationConfigSuccessResponse
-    {
-        fn from(value: super::GetTaskPushNotificationConfigSuccessResponse) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
+                name: Ok(value.name),
+                tenant: Ok(value.tenant),
             }
         }
     }
     #[derive(Clone, Debug)]
     pub struct GetTaskRequest {
-        id: ::std::result::Result<super::GetTaskRequestId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<super::TaskQueryParams, ::std::string::String>,
+        history_length: ::std::result::Result<::std::option::Option<i32>, ::std::string::String>,
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
     }
     impl ::std::default::Default for GetTaskRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                history_length: Ok(Default::default()),
+                name: Err("no value supplied for name".to_string()),
+                tenant: Ok(Default::default()),
             }
         }
     }
     impl GetTaskRequest {
-        pub fn id<T>(mut self, value: T) -> Self
+        pub fn history_length<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::GetTaskRequestId>,
+            T: ::std::convert::TryInto<::std::option::Option<i32>>,
             T::Error: ::std::fmt::Display,
         {
-            self.id = value
+            self.history_length = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for history_length: {e}"));
             self
         }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn name<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
-        pub fn method<T>(mut self, value: T) -> Self
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::string::String>,
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
             T::Error: ::std::fmt::Display,
         {
-            self.method = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::TaskQueryParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -9642,88 +4910,18 @@ pub mod builder {
             value: GetTaskRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                history_length: value.history_length?,
+                name: value.name?,
+                tenant: value.tenant?,
             })
         }
     }
     impl ::std::convert::From<super::GetTaskRequest> for GetTaskRequest {
         fn from(value: super::GetTaskRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct GetTaskSuccessResponse {
-        id: ::std::result::Result<super::GetTaskSuccessResponseId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<super::Task, ::std::string::String>,
-    }
-    impl ::std::default::Default for GetTaskSuccessResponse {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
-            }
-        }
-    }
-    impl GetTaskSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::GetTaskSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::Task>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<GetTaskSuccessResponse> for super::GetTaskSuccessResponse {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: GetTaskSuccessResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::GetTaskSuccessResponse> for GetTaskSuccessResponse {
-        fn from(value: super::GetTaskSuccessResponse) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
+                history_length: Ok(value.history_length),
+                name: Ok(value.name),
+                tenant: Ok(value.tenant),
             }
         }
     }
@@ -9738,7 +4936,6 @@ pub mod builder {
             ::std::string::String,
         >,
         scheme: ::std::result::Result<::std::string::String, ::std::string::String>,
-        type_: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for HttpAuthSecurityScheme {
         fn default() -> Self {
@@ -9746,7 +4943,6 @@ pub mod builder {
                 bearer_format: Ok(Default::default()),
                 description: Ok(Default::default()),
                 scheme: Err("no value supplied for scheme".to_string()),
-                type_: Err("no value supplied for type_".to_string()),
             }
         }
     }
@@ -9758,7 +4954,7 @@ pub mod builder {
         {
             self.bearer_format = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for bearer_format: {}", e));
+                .map_err(|e| format!("error converting supplied value for bearer_format: {e}"));
             self
         }
         pub fn description<T>(mut self, value: T) -> Self
@@ -9768,7 +4964,7 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn scheme<T>(mut self, value: T) -> Self
@@ -9778,17 +4974,7 @@ pub mod builder {
         {
             self.scheme = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for scheme: {}", e));
-            self
-        }
-        pub fn type_<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.type_ = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+                .map_err(|e| format!("error converting supplied value for scheme: {e}"));
             self
         }
     }
@@ -9801,7 +4987,6 @@ pub mod builder {
                 bearer_format: value.bearer_format?,
                 description: value.description?,
                 scheme: value.scheme?,
-                type_: value.type_?,
             })
         }
     }
@@ -9811,7 +4996,6 @@ pub mod builder {
                 bearer_format: Ok(value.bearer_format),
                 description: Ok(value.description),
                 scheme: Ok(value.scheme),
-                type_: Ok(value.type_),
             }
         }
     }
@@ -9842,12 +5026,9 @@ pub mod builder {
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.authorization_url = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for authorization_url: {}",
-                    e
-                )
-            });
+            self.authorization_url = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for authorization_url: {e}"));
             self
         }
         pub fn refresh_url<T>(mut self, value: T) -> Self
@@ -9857,7 +5038,7 @@ pub mod builder {
         {
             self.refresh_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for refresh_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for refresh_url: {e}"));
             self
         }
         pub fn scopes<T>(mut self, value: T) -> Self
@@ -9869,7 +5050,7 @@ pub mod builder {
         {
             self.scopes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for scopes: {}", e));
+                .map_err(|e| format!("error converting supplied value for scopes: {e}"));
             self
         }
     }
@@ -9895,1260 +5076,61 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    pub struct InternalError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for InternalError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl InternalError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<InternalError> for super::InternalError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: InternalError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::InternalError> for InternalError {
-        fn from(value: super::InternalError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct InvalidAgentResponseError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for InvalidAgentResponseError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl InvalidAgentResponseError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<InvalidAgentResponseError> for super::InvalidAgentResponseError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: InvalidAgentResponseError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::InvalidAgentResponseError> for InvalidAgentResponseError {
-        fn from(value: super::InvalidAgentResponseError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct InvalidParamsError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for InvalidParamsError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl InvalidParamsError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<InvalidParamsError> for super::InvalidParamsError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: InvalidParamsError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::InvalidParamsError> for InvalidParamsError {
-        fn from(value: super::InvalidParamsError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct InvalidRequestError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for InvalidRequestError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl InvalidRequestError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<InvalidRequestError> for super::InvalidRequestError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: InvalidRequestError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::InvalidRequestError> for InvalidRequestError {
-        fn from(value: super::InvalidRequestError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonParseError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for JsonParseError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl JsonParseError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonParseError> for super::JsonParseError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonParseError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonParseError> for JsonParseError {
-        fn from(value: super::JsonParseError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for JsonrpcError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl JsonrpcError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcError> for super::JsonrpcError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcError> for JsonrpcError {
-        fn from(value: super::JsonrpcError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcErrorResponse {
-        error: ::std::result::Result<super::JsonrpcErrorResponseError, ::std::string::String>,
-        id: ::std::result::Result<super::JsonrpcErrorResponseId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for JsonrpcErrorResponse {
-        fn default() -> Self {
-            Self {
-                error: Err("no value supplied for error".to_string()),
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-            }
-        }
-    }
-    impl JsonrpcErrorResponse {
-        pub fn error<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::JsonrpcErrorResponseError>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.error = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for error: {}", e));
-            self
-        }
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::JsonrpcErrorResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcErrorResponse> for super::JsonrpcErrorResponse {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcErrorResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                error: value.error?,
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcErrorResponse> for JsonrpcErrorResponse {
-        fn from(value: super::JsonrpcErrorResponse) -> Self {
-            Self {
-                error: Ok(value.error),
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcErrorResponseError {
-        subtype_0: ::std::result::Result<
-            ::std::option::Option<super::JsonrpcError>,
-            ::std::string::String,
-        >,
-        subtype_1: ::std::result::Result<
-            ::std::option::Option<super::JsonParseError>,
-            ::std::string::String,
-        >,
-        subtype_2: ::std::result::Result<
-            ::std::option::Option<super::InvalidRequestError>,
-            ::std::string::String,
-        >,
-        subtype_3: ::std::result::Result<
-            ::std::option::Option<super::MethodNotFoundError>,
-            ::std::string::String,
-        >,
-        subtype_4: ::std::result::Result<
-            ::std::option::Option<super::InvalidParamsError>,
-            ::std::string::String,
-        >,
-        subtype_5: ::std::result::Result<
-            ::std::option::Option<super::InternalError>,
-            ::std::string::String,
-        >,
-        subtype_6: ::std::result::Result<
-            ::std::option::Option<super::TaskNotFoundError>,
-            ::std::string::String,
-        >,
-        subtype_7: ::std::result::Result<
-            ::std::option::Option<super::TaskNotCancelableError>,
-            ::std::string::String,
-        >,
-        subtype_8: ::std::result::Result<
-            ::std::option::Option<super::PushNotificationNotSupportedError>,
-            ::std::string::String,
-        >,
-        subtype_9: ::std::result::Result<
-            ::std::option::Option<super::UnsupportedOperationError>,
-            ::std::string::String,
-        >,
-        subtype_10: ::std::result::Result<
-            ::std::option::Option<super::ContentTypeNotSupportedError>,
-            ::std::string::String,
-        >,
-        subtype_11: ::std::result::Result<
-            ::std::option::Option<super::InvalidAgentResponseError>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for JsonrpcErrorResponseError {
-        fn default() -> Self {
-            Self {
-                subtype_0: Ok(Default::default()),
-                subtype_1: Ok(Default::default()),
-                subtype_2: Ok(Default::default()),
-                subtype_3: Ok(Default::default()),
-                subtype_4: Ok(Default::default()),
-                subtype_5: Ok(Default::default()),
-                subtype_6: Ok(Default::default()),
-                subtype_7: Ok(Default::default()),
-                subtype_8: Ok(Default::default()),
-                subtype_9: Ok(Default::default()),
-                subtype_10: Ok(Default::default()),
-                subtype_11: Ok(Default::default()),
-            }
-        }
-    }
-    impl JsonrpcErrorResponseError {
-        pub fn subtype_0<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::JsonrpcError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_0 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_0: {}", e));
-            self
-        }
-        pub fn subtype_1<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::JsonParseError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_1 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_1: {}", e));
-            self
-        }
-        pub fn subtype_2<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InvalidRequestError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_2 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_2: {}", e));
-            self
-        }
-        pub fn subtype_3<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::MethodNotFoundError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_3 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_3: {}", e));
-            self
-        }
-        pub fn subtype_4<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InvalidParamsError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_4 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_4: {}", e));
-            self
-        }
-        pub fn subtype_5<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InternalError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_5 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_5: {}", e));
-            self
-        }
-        pub fn subtype_6<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::TaskNotFoundError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_6 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_6: {}", e));
-            self
-        }
-        pub fn subtype_7<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::TaskNotCancelableError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_7 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_7: {}", e));
-            self
-        }
-        pub fn subtype_8<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::PushNotificationNotSupportedError>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_8 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_8: {}", e));
-            self
-        }
-        pub fn subtype_9<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::UnsupportedOperationError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_9 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_9: {}", e));
-            self
-        }
-        pub fn subtype_10<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::ContentTypeNotSupportedError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_10 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_10: {}", e));
-            self
-        }
-        pub fn subtype_11<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::InvalidAgentResponseError>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_11 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_11: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcErrorResponseError> for super::JsonrpcErrorResponseError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcErrorResponseError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                subtype_0: value.subtype_0?,
-                subtype_1: value.subtype_1?,
-                subtype_2: value.subtype_2?,
-                subtype_3: value.subtype_3?,
-                subtype_4: value.subtype_4?,
-                subtype_5: value.subtype_5?,
-                subtype_6: value.subtype_6?,
-                subtype_7: value.subtype_7?,
-                subtype_8: value.subtype_8?,
-                subtype_9: value.subtype_9?,
-                subtype_10: value.subtype_10?,
-                subtype_11: value.subtype_11?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcErrorResponseError> for JsonrpcErrorResponseError {
-        fn from(value: super::JsonrpcErrorResponseError) -> Self {
-            Self {
-                subtype_0: Ok(value.subtype_0),
-                subtype_1: Ok(value.subtype_1),
-                subtype_2: Ok(value.subtype_2),
-                subtype_3: Ok(value.subtype_3),
-                subtype_4: Ok(value.subtype_4),
-                subtype_5: Ok(value.subtype_5),
-                subtype_6: Ok(value.subtype_6),
-                subtype_7: Ok(value.subtype_7),
-                subtype_8: Ok(value.subtype_8),
-                subtype_9: Ok(value.subtype_9),
-                subtype_10: Ok(value.subtype_10),
-                subtype_11: Ok(value.subtype_11),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcMessage {
-        id: ::std::result::Result<
-            ::std::option::Option<super::JsonrpcMessageId>,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for JsonrpcMessage {
-        fn default() -> Self {
-            Self {
-                id: Ok(Default::default()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-            }
-        }
-    }
-    impl JsonrpcMessage {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::JsonrpcMessageId>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcMessage> for super::JsonrpcMessage {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcMessage,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcMessage> for JsonrpcMessage {
-        fn from(value: super::JsonrpcMessage) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcRequest {
-        id: ::std::result::Result<
-            ::std::option::Option<super::JsonrpcRequestId>,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for JsonrpcRequest {
-        fn default() -> Self {
-            Self {
-                id: Ok(Default::default()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Ok(Default::default()),
-            }
-        }
-    }
-    impl JsonrpcRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::JsonrpcRequestId>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn method<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.method = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcRequest> for super::JsonrpcRequest {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcRequest,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcRequest> for JsonrpcRequest {
-        fn from(value: super::JsonrpcRequest) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcResponse {
-        subtype_0: ::std::result::Result<
-            ::std::option::Option<super::JsonrpcErrorResponse>,
-            ::std::string::String,
-        >,
-        subtype_1: ::std::result::Result<
-            ::std::option::Option<super::SendMessageSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_2: ::std::result::Result<
-            ::std::option::Option<super::SendStreamingMessageSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_3: ::std::result::Result<
-            ::std::option::Option<super::GetTaskSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_4: ::std::result::Result<
-            ::std::option::Option<super::CancelTaskSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_5: ::std::result::Result<
-            ::std::option::Option<super::SetTaskPushNotificationConfigSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_6: ::std::result::Result<
-            ::std::option::Option<super::GetTaskPushNotificationConfigSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_7: ::std::result::Result<
-            ::std::option::Option<super::ListTaskPushNotificationConfigSuccessResponse>,
-            ::std::string::String,
-        >,
-        subtype_8: ::std::result::Result<
-            ::std::option::Option<super::DeleteTaskPushNotificationConfigSuccessResponse>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for JsonrpcResponse {
-        fn default() -> Self {
-            Self {
-                subtype_0: Ok(Default::default()),
-                subtype_1: Ok(Default::default()),
-                subtype_2: Ok(Default::default()),
-                subtype_3: Ok(Default::default()),
-                subtype_4: Ok(Default::default()),
-                subtype_5: Ok(Default::default()),
-                subtype_6: Ok(Default::default()),
-                subtype_7: Ok(Default::default()),
-                subtype_8: Ok(Default::default()),
-            }
-        }
-    }
-    impl JsonrpcResponse {
-        pub fn subtype_0<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::JsonrpcErrorResponse>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_0 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_0: {}", e));
-            self
-        }
-        pub fn subtype_1<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::SendMessageSuccessResponse>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_1 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_1: {}", e));
-            self
-        }
-        pub fn subtype_2<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::SendStreamingMessageSuccessResponse>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_2 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_2: {}", e));
-            self
-        }
-        pub fn subtype_3<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::GetTaskSuccessResponse>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_3 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_3: {}", e));
-            self
-        }
-        pub fn subtype_4<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::CancelTaskSuccessResponse>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_4 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_4: {}", e));
-            self
-        }
-        pub fn subtype_5<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::SetTaskPushNotificationConfigSuccessResponse>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_5 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_5: {}", e));
-            self
-        }
-        pub fn subtype_6<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::GetTaskPushNotificationConfigSuccessResponse>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_6 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_6: {}", e));
-            self
-        }
-        pub fn subtype_7<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::ListTaskPushNotificationConfigSuccessResponse>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_7 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_7: {}", e));
-            self
-        }
-        pub fn subtype_8<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::DeleteTaskPushNotificationConfigSuccessResponse>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.subtype_8 = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for subtype_8: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcResponse> for super::JsonrpcResponse {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                subtype_0: value.subtype_0?,
-                subtype_1: value.subtype_1?,
-                subtype_2: value.subtype_2?,
-                subtype_3: value.subtype_3?,
-                subtype_4: value.subtype_4?,
-                subtype_5: value.subtype_5?,
-                subtype_6: value.subtype_6?,
-                subtype_7: value.subtype_7?,
-                subtype_8: value.subtype_8?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcResponse> for JsonrpcResponse {
-        fn from(value: super::JsonrpcResponse) -> Self {
-            Self {
-                subtype_0: Ok(value.subtype_0),
-                subtype_1: Ok(value.subtype_1),
-                subtype_2: Ok(value.subtype_2),
-                subtype_3: Ok(value.subtype_3),
-                subtype_4: Ok(value.subtype_4),
-                subtype_5: Ok(value.subtype_5),
-                subtype_6: Ok(value.subtype_6),
-                subtype_7: Ok(value.subtype_7),
-                subtype_8: Ok(value.subtype_8),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct JsonrpcSuccessResponse {
-        id: ::std::result::Result<super::JsonrpcSuccessResponseId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<::serde_json::Value, ::std::string::String>,
-    }
-    impl ::std::default::Default for JsonrpcSuccessResponse {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
-            }
-        }
-    }
-    impl JsonrpcSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::JsonrpcSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::serde_json::Value>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<JsonrpcSuccessResponse> for super::JsonrpcSuccessResponse {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: JsonrpcSuccessResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::JsonrpcSuccessResponse> for JsonrpcSuccessResponse {
-        fn from(value: super::JsonrpcSuccessResponse) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct ListTaskPushNotificationConfigParams {
-        id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for ListTaskPushNotificationConfigParams {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                metadata: Ok(Default::default()),
-            }
-        }
-    }
-    impl ListTaskPushNotificationConfigParams {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<ListTaskPushNotificationConfigParams>
-        for super::ListTaskPushNotificationConfigParams
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: ListTaskPushNotificationConfigParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                metadata: value.metadata?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::ListTaskPushNotificationConfigParams>
-        for ListTaskPushNotificationConfigParams
-    {
-        fn from(value: super::ListTaskPushNotificationConfigParams) -> Self {
-            Self {
-                id: Ok(value.id),
-                metadata: Ok(value.metadata),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
     pub struct ListTaskPushNotificationConfigRequest {
-        id: ::std::result::Result<
-            super::ListTaskPushNotificationConfigRequestId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<
-            super::ListTaskPushNotificationConfigParams,
-            ::std::string::String,
-        >,
+        page_size: ::std::result::Result<i32, ::std::string::String>,
+        page_token: ::std::result::Result<::std::string::String, ::std::string::String>,
+        parent: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for ListTaskPushNotificationConfigRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                page_size: Err("no value supplied for page_size".to_string()),
+                page_token: Err("no value supplied for page_token".to_string()),
+                parent: Err("no value supplied for parent".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
             }
         }
     }
     impl ListTaskPushNotificationConfigRequest {
-        pub fn id<T>(mut self, value: T) -> Self
+        pub fn page_size<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::ListTaskPushNotificationConfigRequestId>,
+            T: ::std::convert::TryInto<i32>,
             T::Error: ::std::fmt::Display,
         {
-            self.id = value
+            self.page_size = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for page_size: {e}"));
             self
         }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn page_token<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.page_token = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
+                .map_err(|e| format!("error converting supplied value for page_token: {e}"));
             self
         }
-        pub fn method<T>(mut self, value: T) -> Self
+        pub fn parent<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.method = value
+            self.parent = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
+                .map_err(|e| format!("error converting supplied value for parent: {e}"));
             self
         }
-        pub fn params<T>(mut self, value: T) -> Self
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::ListTaskPushNotificationConfigParams>,
+            T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.params = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -11160,10 +5142,10 @@ pub mod builder {
             value: ListTaskPushNotificationConfigRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                page_size: value.page_size?,
+                page_token: value.page_token?,
+                parent: value.parent?,
+                tenant: value.tenant?,
             })
         }
     }
@@ -11172,88 +5154,292 @@ pub mod builder {
     {
         fn from(value: super::ListTaskPushNotificationConfigRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
+                page_size: Ok(value.page_size),
+                page_token: Ok(value.page_token),
+                parent: Ok(value.parent),
+                tenant: Ok(value.tenant),
             }
         }
     }
     #[derive(Clone, Debug)]
-    pub struct ListTaskPushNotificationConfigSuccessResponse {
-        id: ::std::result::Result<
-            super::ListTaskPushNotificationConfigSuccessResponseId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<
+    pub struct ListTaskPushNotificationConfigResponse {
+        configs: ::std::result::Result<
             ::std::vec::Vec<super::TaskPushNotificationConfig>,
             ::std::string::String,
         >,
+        next_page_token: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
-    impl ::std::default::Default for ListTaskPushNotificationConfigSuccessResponse {
+    impl ::std::default::Default for ListTaskPushNotificationConfigResponse {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
+                configs: Ok(Default::default()),
+                next_page_token: Err("no value supplied for next_page_token".to_string()),
             }
         }
     }
-    impl ListTaskPushNotificationConfigSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::ListTaskPushNotificationConfigSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
+    impl ListTaskPushNotificationConfigResponse {
+        pub fn configs<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::vec::Vec<super::TaskPushNotificationConfig>>,
             T::Error: ::std::fmt::Display,
         {
-            self.result = value
+            self.configs = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for configs: {e}"));
+            self
+        }
+        pub fn next_page_token<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.next_page_token = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for next_page_token: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<ListTaskPushNotificationConfigSuccessResponse>
-        for super::ListTaskPushNotificationConfigSuccessResponse
+    impl ::std::convert::TryFrom<ListTaskPushNotificationConfigResponse>
+        for super::ListTaskPushNotificationConfigResponse
     {
         type Error = super::error::ConversionError;
         fn try_from(
-            value: ListTaskPushNotificationConfigSuccessResponse,
+            value: ListTaskPushNotificationConfigResponse,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
+                configs: value.configs?,
+                next_page_token: value.next_page_token?,
             })
         }
     }
-    impl ::std::convert::From<super::ListTaskPushNotificationConfigSuccessResponse>
-        for ListTaskPushNotificationConfigSuccessResponse
+    impl ::std::convert::From<super::ListTaskPushNotificationConfigResponse>
+        for ListTaskPushNotificationConfigResponse
     {
-        fn from(value: super::ListTaskPushNotificationConfigSuccessResponse) -> Self {
+        fn from(value: super::ListTaskPushNotificationConfigResponse) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
+                configs: Ok(value.configs),
+                next_page_token: Ok(value.next_page_token),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ListTasksRequest {
+        context_id: ::std::result::Result<::std::string::String, ::std::string::String>,
+        history_length: ::std::result::Result<::std::option::Option<i32>, ::std::string::String>,
+        include_artifacts:
+            ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
+        last_updated_after: ::std::result::Result<i64, ::std::string::String>,
+        page_size: ::std::result::Result<::std::option::Option<i32>, ::std::string::String>,
+        page_token: ::std::result::Result<::std::string::String, ::std::string::String>,
+        status: ::std::result::Result<super::TaskState, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
+    }
+    impl ::std::default::Default for ListTasksRequest {
+        fn default() -> Self {
+            Self {
+                context_id: Err("no value supplied for context_id".to_string()),
+                history_length: Ok(Default::default()),
+                include_artifacts: Ok(Default::default()),
+                last_updated_after: Err("no value supplied for last_updated_after".to_string()),
+                page_size: Ok(Default::default()),
+                page_token: Err("no value supplied for page_token".to_string()),
+                status: Err("no value supplied for status".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
+            }
+        }
+    }
+    impl ListTasksRequest {
+        pub fn context_id<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.context_id = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for context_id: {e}"));
+            self
+        }
+        pub fn history_length<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<i32>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.history_length = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for history_length: {e}"));
+            self
+        }
+        pub fn include_artifacts<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<bool>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.include_artifacts = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for include_artifacts: {e}"));
+            self
+        }
+        pub fn last_updated_after<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<i64>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.last_updated_after = value.try_into().map_err(|e| {
+                format!("error converting supplied value for last_updated_after: {e}")
+            });
+            self
+        }
+        pub fn page_size<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<i32>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.page_size = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for page_size: {e}"));
+            self
+        }
+        pub fn page_token<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.page_token = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for page_token: {e}"));
+            self
+        }
+        pub fn status<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<super::TaskState>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.status = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for status: {e}"));
+            self
+        }
+        pub fn tenant<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.tenant = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<ListTasksRequest> for super::ListTasksRequest {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: ListTasksRequest,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                context_id: value.context_id?,
+                history_length: value.history_length?,
+                include_artifacts: value.include_artifacts?,
+                last_updated_after: value.last_updated_after?,
+                page_size: value.page_size?,
+                page_token: value.page_token?,
+                status: value.status?,
+                tenant: value.tenant?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::ListTasksRequest> for ListTasksRequest {
+        fn from(value: super::ListTasksRequest) -> Self {
+            Self {
+                context_id: Ok(value.context_id),
+                history_length: Ok(value.history_length),
+                include_artifacts: Ok(value.include_artifacts),
+                last_updated_after: Ok(value.last_updated_after),
+                page_size: Ok(value.page_size),
+                page_token: Ok(value.page_token),
+                status: Ok(value.status),
+                tenant: Ok(value.tenant),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ListTasksResponse {
+        next_page_token: ::std::result::Result<::std::string::String, ::std::string::String>,
+        page_size: ::std::result::Result<i32, ::std::string::String>,
+        tasks: ::std::result::Result<::std::vec::Vec<super::Task>, ::std::string::String>,
+        total_size: ::std::result::Result<i32, ::std::string::String>,
+    }
+    impl ::std::default::Default for ListTasksResponse {
+        fn default() -> Self {
+            Self {
+                next_page_token: Err("no value supplied for next_page_token".to_string()),
+                page_size: Err("no value supplied for page_size".to_string()),
+                tasks: Err("no value supplied for tasks".to_string()),
+                total_size: Err("no value supplied for total_size".to_string()),
+            }
+        }
+    }
+    impl ListTasksResponse {
+        pub fn next_page_token<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.next_page_token = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for next_page_token: {e}"));
+            self
+        }
+        pub fn page_size<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<i32>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.page_size = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for page_size: {e}"));
+            self
+        }
+        pub fn tasks<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<super::Task>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.tasks = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for tasks: {e}"));
+            self
+        }
+        pub fn total_size<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<i32>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.total_size = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for total_size: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<ListTasksResponse> for super::ListTasksResponse {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: ListTasksResponse,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                next_page_token: value.next_page_token?,
+                page_size: value.page_size?,
+                tasks: value.tasks?,
+                total_size: value.total_size?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::ListTasksResponse> for ListTasksResponse {
+        fn from(value: super::ListTasksResponse) -> Self {
+            Self {
+                next_page_token: Ok(value.next_page_token),
+                page_size: Ok(value.page_size),
+                tasks: Ok(value.tasks),
+                total_size: Ok(value.total_size),
             }
         }
     }
@@ -11265,16 +5451,13 @@ pub mod builder {
         >,
         extensions:
             ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
         message_id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
         parts: ::std::result::Result<::std::vec::Vec<super::Part>, ::std::string::String>,
         reference_task_ids:
             ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
-        role: ::std::result::Result<super::MessageRole, ::std::string::String>,
+        role: ::std::result::Result<super::Role, ::std::string::String>,
         task_id: ::std::result::Result<
             ::std::option::Option<::std::string::String>,
             ::std::string::String,
@@ -11285,7 +5468,6 @@ pub mod builder {
             Self {
                 context_id: Ok(Default::default()),
                 extensions: Ok(Default::default()),
-                kind: Err("no value supplied for kind".to_string()),
                 message_id: Err("no value supplied for message_id".to_string()),
                 metadata: Ok(Default::default()),
                 parts: Err("no value supplied for parts".to_string()),
@@ -11303,7 +5485,7 @@ pub mod builder {
         {
             self.context_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for context_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for context_id: {e}"));
             self
         }
         pub fn extensions<T>(mut self, value: T) -> Self
@@ -11313,17 +5495,7 @@ pub mod builder {
         {
             self.extensions = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for extensions: {}", e));
-            self
-        }
-        pub fn kind<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.kind = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                .map_err(|e| format!("error converting supplied value for extensions: {e}"));
             self
         }
         pub fn message_id<T>(mut self, value: T) -> Self
@@ -11333,19 +5505,17 @@ pub mod builder {
         {
             self.message_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for message_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for message_id: {e}"));
             self
         }
         pub fn metadata<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.metadata = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
             self
         }
         pub fn parts<T>(mut self, value: T) -> Self
@@ -11355,7 +5525,7 @@ pub mod builder {
         {
             self.parts = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for parts: {}", e));
+                .map_err(|e| format!("error converting supplied value for parts: {e}"));
             self
         }
         pub fn reference_task_ids<T>(mut self, value: T) -> Self
@@ -11364,21 +5534,18 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.reference_task_ids = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for reference_task_ids: {}",
-                    e
-                )
+                format!("error converting supplied value for reference_task_ids: {e}")
             });
             self
         }
         pub fn role<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::MessageRole>,
+            T: ::std::convert::TryInto<super::Role>,
             T::Error: ::std::fmt::Display,
         {
             self.role = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for role: {}", e));
+                .map_err(|e| format!("error converting supplied value for role: {e}"));
             self
         }
         pub fn task_id<T>(mut self, value: T) -> Self
@@ -11388,7 +5555,7 @@ pub mod builder {
         {
             self.task_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for task_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for task_id: {e}"));
             self
         }
     }
@@ -11398,7 +5565,6 @@ pub mod builder {
             Ok(Self {
                 context_id: value.context_id?,
                 extensions: value.extensions?,
-                kind: value.kind?,
                 message_id: value.message_id?,
                 metadata: value.metadata?,
                 parts: value.parts?,
@@ -11413,7 +5579,6 @@ pub mod builder {
             Self {
                 context_id: Ok(value.context_id),
                 extensions: Ok(value.extensions),
-                kind: Ok(value.kind),
                 message_id: Ok(value.message_id),
                 metadata: Ok(value.metadata),
                 parts: Ok(value.parts),
@@ -11424,241 +5589,42 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    pub struct MessageSendConfiguration {
-        accepted_output_modes:
-            ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
-        blocking: ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
-        history_length: ::std::result::Result<::std::option::Option<i64>, ::std::string::String>,
-        push_notification_config: ::std::result::Result<
-            ::std::option::Option<super::PushNotificationConfig>,
-            ::std::string::String,
-        >,
+    pub struct MutualTlsSecurityScheme {
+        description: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
-    impl ::std::default::Default for MessageSendConfiguration {
+    impl ::std::default::Default for MutualTlsSecurityScheme {
         fn default() -> Self {
             Self {
-                accepted_output_modes: Ok(Default::default()),
-                blocking: Ok(Default::default()),
-                history_length: Ok(Default::default()),
-                push_notification_config: Ok(Default::default()),
+                description: Err("no value supplied for description".to_string()),
             }
         }
     }
-    impl MessageSendConfiguration {
-        pub fn accepted_output_modes<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.accepted_output_modes = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for accepted_output_modes: {}",
-                    e
-                )
-            });
-            self
-        }
-        pub fn blocking<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<bool>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.blocking = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for blocking: {}", e));
-            self
-        }
-        pub fn history_length<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<i64>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.history_length = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for history_length: {}", e));
-            self
-        }
-        pub fn push_notification_config<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::PushNotificationConfig>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.push_notification_config = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for push_notification_config: {}",
-                    e
-                )
-            });
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<MessageSendConfiguration> for super::MessageSendConfiguration {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: MessageSendConfiguration,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                accepted_output_modes: value.accepted_output_modes?,
-                blocking: value.blocking?,
-                history_length: value.history_length?,
-                push_notification_config: value.push_notification_config?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::MessageSendConfiguration> for MessageSendConfiguration {
-        fn from(value: super::MessageSendConfiguration) -> Self {
-            Self {
-                accepted_output_modes: Ok(value.accepted_output_modes),
-                blocking: Ok(value.blocking),
-                history_length: Ok(value.history_length),
-                push_notification_config: Ok(value.push_notification_config),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct MessageSendParams {
-        configuration: ::std::result::Result<
-            ::std::option::Option<super::MessageSendConfiguration>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<super::Message, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for MessageSendParams {
-        fn default() -> Self {
-            Self {
-                configuration: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-                metadata: Ok(Default::default()),
-            }
-        }
-    }
-    impl MessageSendParams {
-        pub fn configuration<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<super::MessageSendConfiguration>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.configuration = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for configuration: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::Message>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<MessageSendParams> for super::MessageSendParams {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: MessageSendParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                configuration: value.configuration?,
-                message: value.message?,
-                metadata: value.metadata?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::MessageSendParams> for MessageSendParams {
-        fn from(value: super::MessageSendParams) -> Self {
-            Self {
-                configuration: Ok(value.configuration),
-                message: Ok(value.message),
-                metadata: Ok(value.metadata),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct MethodNotFoundError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for MethodNotFoundError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl MethodNotFoundError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
+    impl MutualTlsSecurityScheme {
+        pub fn description<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.message = value
+            self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<MethodNotFoundError> for super::MethodNotFoundError {
+    impl ::std::convert::TryFrom<MutualTlsSecurityScheme> for super::MutualTlsSecurityScheme {
         type Error = super::error::ConversionError;
         fn try_from(
-            value: MethodNotFoundError,
+            value: MutualTlsSecurityScheme,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
+                description: value.description?,
             })
         }
     }
-    impl ::std::convert::From<super::MethodNotFoundError> for MethodNotFoundError {
-        fn from(value: super::MethodNotFoundError) -> Self {
+    impl ::std::convert::From<super::MutualTlsSecurityScheme> for MutualTlsSecurityScheme {
+        fn from(value: super::MutualTlsSecurityScheme) -> Self {
             Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
+                description: Ok(value.description),
             }
         }
     }
@@ -11669,14 +5635,17 @@ pub mod builder {
             ::std::string::String,
         >,
         flows: ::std::result::Result<super::OAuthFlows, ::std::string::String>,
-        type_: ::std::result::Result<::std::string::String, ::std::string::String>,
+        oauth2_metadata_url: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
+            ::std::string::String,
+        >,
     }
     impl ::std::default::Default for OAuth2SecurityScheme {
         fn default() -> Self {
             Self {
                 description: Ok(Default::default()),
                 flows: Err("no value supplied for flows".to_string()),
-                type_: Err("no value supplied for type_".to_string()),
+                oauth2_metadata_url: Ok(Default::default()),
             }
         }
     }
@@ -11688,7 +5657,7 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn flows<T>(mut self, value: T) -> Self
@@ -11698,17 +5667,17 @@ pub mod builder {
         {
             self.flows = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for flows: {}", e));
+                .map_err(|e| format!("error converting supplied value for flows: {e}"));
             self
         }
-        pub fn type_<T>(mut self, value: T) -> Self
+        pub fn oauth2_metadata_url<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::string::String>,
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
             T::Error: ::std::fmt::Display,
         {
-            self.type_ = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
+            self.oauth2_metadata_url = value.try_into().map_err(|e| {
+                format!("error converting supplied value for oauth2_metadata_url: {e}")
+            });
             self
         }
     }
@@ -11720,7 +5689,7 @@ pub mod builder {
             Ok(Self {
                 description: value.description?,
                 flows: value.flows?,
-                type_: value.type_?,
+                oauth2_metadata_url: value.oauth2_metadata_url?,
             })
         }
     }
@@ -11729,7 +5698,7 @@ pub mod builder {
             Self {
                 description: Ok(value.description),
                 flows: Ok(value.flows),
-                type_: Ok(value.type_),
+                oauth2_metadata_url: Ok(value.oauth2_metadata_url),
             }
         }
     }
@@ -11769,10 +5738,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.authorization_code = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for authorization_code: {}",
-                    e
-                )
+                format!("error converting supplied value for authorization_code: {e}")
             });
             self
         }
@@ -11782,10 +5748,7 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.client_credentials = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for client_credentials: {}",
-                    e
-                )
+                format!("error converting supplied value for client_credentials: {e}")
             });
             self
         }
@@ -11796,7 +5759,7 @@ pub mod builder {
         {
             self.implicit = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for implicit: {}", e));
+                .map_err(|e| format!("error converting supplied value for implicit: {e}"));
             self
         }
         pub fn password<T>(mut self, value: T) -> Self
@@ -11806,7 +5769,7 @@ pub mod builder {
         {
             self.password = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for password: {}", e));
+                .map_err(|e| format!("error converting supplied value for password: {e}"));
             self
         }
     }
@@ -11840,14 +5803,12 @@ pub mod builder {
             ::std::string::String,
         >,
         open_id_connect_url: ::std::result::Result<::std::string::String, ::std::string::String>,
-        type_: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for OpenIdConnectSecurityScheme {
         fn default() -> Self {
             Self {
                 description: Ok(Default::default()),
                 open_id_connect_url: Err("no value supplied for open_id_connect_url".to_string()),
-                type_: Err("no value supplied for type_".to_string()),
             }
         }
     }
@@ -11859,7 +5820,7 @@ pub mod builder {
         {
             self.description = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+                .map_err(|e| format!("error converting supplied value for description: {e}"));
             self
         }
         pub fn open_id_connect_url<T>(mut self, value: T) -> Self
@@ -11868,21 +5829,8 @@ pub mod builder {
             T::Error: ::std::fmt::Display,
         {
             self.open_id_connect_url = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for open_id_connect_url: {}",
-                    e
-                )
+                format!("error converting supplied value for open_id_connect_url: {e}")
             });
-            self
-        }
-        pub fn type_<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.type_ = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for type_: {}", e));
             self
         }
     }
@@ -11894,7 +5842,6 @@ pub mod builder {
             Ok(Self {
                 description: value.description?,
                 open_id_connect_url: value.open_id_connect_url?,
-                type_: value.type_?,
             })
         }
     }
@@ -11903,50 +5850,90 @@ pub mod builder {
             Self {
                 description: Ok(value.description),
                 open_id_connect_url: Ok(value.open_id_connect_url),
-                type_: Ok(value.type_),
             }
         }
     }
     #[derive(Clone, Debug)]
-    pub struct PartBase {
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+    pub struct Part {
+        data: ::std::result::Result<::std::option::Option<super::DataPart>, ::std::string::String>,
+        file: ::std::result::Result<::std::option::Option<super::FilePart>, ::std::string::String>,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
+        text: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
             ::std::string::String,
         >,
     }
-    impl ::std::default::Default for PartBase {
+    impl ::std::default::Default for Part {
         fn default() -> Self {
             Self {
+                data: Ok(Default::default()),
+                file: Ok(Default::default()),
                 metadata: Ok(Default::default()),
+                text: Ok(Default::default()),
             }
         }
     }
-    impl PartBase {
+    impl Part {
+        pub fn data<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::DataPart>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.data = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for data: {e}"));
+            self
+        }
+        pub fn file<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::FilePart>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.file = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for file: {e}"));
+            self
+        }
         pub fn metadata<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.metadata = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
+            self
+        }
+        pub fn text<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.text = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for text: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<PartBase> for super::PartBase {
+    impl ::std::convert::TryFrom<Part> for super::Part {
         type Error = super::error::ConversionError;
-        fn try_from(value: PartBase) -> ::std::result::Result<Self, super::error::ConversionError> {
+        fn try_from(value: Part) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
+                data: value.data?,
+                file: value.file?,
                 metadata: value.metadata?,
+                text: value.text?,
             })
         }
     }
-    impl ::std::convert::From<super::PartBase> for PartBase {
-        fn from(value: super::PartBase) -> Self {
+    impl ::std::convert::From<super::Part> for Part {
+        fn from(value: super::Part) -> Self {
             Self {
+                data: Ok(value.data),
+                file: Ok(value.file),
                 metadata: Ok(value.metadata),
+                text: Ok(value.text),
             }
         }
     }
@@ -11979,7 +5966,7 @@ pub mod builder {
         {
             self.refresh_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for refresh_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for refresh_url: {e}"));
             self
         }
         pub fn scopes<T>(mut self, value: T) -> Self
@@ -11991,7 +5978,7 @@ pub mod builder {
         {
             self.scopes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for scopes: {}", e));
+                .map_err(|e| format!("error converting supplied value for scopes: {e}"));
             self
         }
         pub fn token_url<T>(mut self, value: T) -> Self
@@ -12001,7 +5988,7 @@ pub mod builder {
         {
             self.token_url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for token_url: {}", e));
+                .map_err(|e| format!("error converting supplied value for token_url: {e}"));
             self
         }
     }
@@ -12027,71 +6014,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    pub struct PushNotificationAuthenticationInfo {
-        credentials: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
-        schemes:
-            ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
-    }
-    impl ::std::default::Default for PushNotificationAuthenticationInfo {
-        fn default() -> Self {
-            Self {
-                credentials: Ok(Default::default()),
-                schemes: Err("no value supplied for schemes".to_string()),
-            }
-        }
-    }
-    impl PushNotificationAuthenticationInfo {
-        pub fn credentials<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.credentials = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for credentials: {}", e));
-            self
-        }
-        pub fn schemes<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.schemes = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for schemes: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<PushNotificationAuthenticationInfo>
-        for super::PushNotificationAuthenticationInfo
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: PushNotificationAuthenticationInfo,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                credentials: value.credentials?,
-                schemes: value.schemes?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::PushNotificationAuthenticationInfo>
-        for PushNotificationAuthenticationInfo
-    {
-        fn from(value: super::PushNotificationAuthenticationInfo) -> Self {
-            Self {
-                credentials: Ok(value.credentials),
-                schemes: Ok(value.schemes),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
     pub struct PushNotificationConfig {
         authentication: ::std::result::Result<
-            ::std::option::Option<super::PushNotificationAuthenticationInfo>,
+            ::std::option::Option<super::AuthenticationInfo>,
             ::std::string::String,
         >,
         id: ::std::result::Result<
@@ -12117,14 +6042,12 @@ pub mod builder {
     impl PushNotificationConfig {
         pub fn authentication<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::std::option::Option<super::PushNotificationAuthenticationInfo>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::AuthenticationInfo>>,
             T::Error: ::std::fmt::Display,
         {
             self.authentication = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for authentication: {}", e));
+                .map_err(|e| format!("error converting supplied value for authentication: {e}"));
             self
         }
         pub fn id<T>(mut self, value: T) -> Self
@@ -12134,7 +6057,7 @@ pub mod builder {
         {
             self.id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for id: {e}"));
             self
         }
         pub fn token<T>(mut self, value: T) -> Self
@@ -12144,7 +6067,7 @@ pub mod builder {
         {
             self.token = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for token: {}", e));
+                .map_err(|e| format!("error converting supplied value for token: {e}"));
             self
         }
         pub fn url<T>(mut self, value: T) -> Self
@@ -12154,7 +6077,7 @@ pub mod builder {
         {
             self.url = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for url: {}", e));
+                .map_err(|e| format!("error converting supplied value for url: {e}"));
             self
         }
     }
@@ -12182,179 +6105,306 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    pub struct PushNotificationNotSupportedError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
+    pub struct Security {
+        schemes: ::std::result::Result<
+            ::std::collections::HashMap<::std::string::String, super::StringList>,
             ::std::string::String,
         >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
-    impl ::std::default::Default for PushNotificationNotSupportedError {
+    impl ::std::default::Default for Security {
         fn default() -> Self {
             Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
+                schemes: Ok(Default::default()),
             }
         }
     }
-    impl PushNotificationNotSupportedError {
-        pub fn code<T>(mut self, value: T) -> Self
+    impl Security {
+        pub fn schemes<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<i64>,
+            T: ::std::convert::TryInto<
+                    ::std::collections::HashMap<::std::string::String, super::StringList>,
+                >,
             T::Error: ::std::fmt::Display,
         {
-            self.code = value
+            self.schemes = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
+                .map_err(|e| format!("error converting supplied value for schemes: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<PushNotificationNotSupportedError>
-        for super::PushNotificationNotSupportedError
-    {
+    impl ::std::convert::TryFrom<Security> for super::Security {
         type Error = super::error::ConversionError;
-        fn try_from(
-            value: PushNotificationNotSupportedError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+        fn try_from(value: Security) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
+                schemes: value.schemes?,
             })
         }
     }
-    impl ::std::convert::From<super::PushNotificationNotSupportedError>
-        for PushNotificationNotSupportedError
-    {
-        fn from(value: super::PushNotificationNotSupportedError) -> Self {
+    impl ::std::convert::From<super::Security> for Security {
+        fn from(value: super::Security) -> Self {
             Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
+                schemes: Ok(value.schemes),
             }
         }
     }
     #[derive(Clone, Debug)]
-    pub struct SecuritySchemeBase {
-        description: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
+    pub struct SecurityScheme {
+        api_key_security_scheme: ::std::result::Result<
+            ::std::option::Option<super::ApiKeySecurityScheme>,
+            ::std::string::String,
+        >,
+        http_auth_security_scheme: ::std::result::Result<
+            ::std::option::Option<super::HttpAuthSecurityScheme>,
+            ::std::string::String,
+        >,
+        mtls_security_scheme: ::std::result::Result<
+            ::std::option::Option<super::MutualTlsSecurityScheme>,
+            ::std::string::String,
+        >,
+        oauth2_security_scheme: ::std::result::Result<
+            ::std::option::Option<super::OAuth2SecurityScheme>,
+            ::std::string::String,
+        >,
+        open_id_connect_security_scheme: ::std::result::Result<
+            ::std::option::Option<super::OpenIdConnectSecurityScheme>,
             ::std::string::String,
         >,
     }
-    impl ::std::default::Default for SecuritySchemeBase {
+    impl ::std::default::Default for SecurityScheme {
         fn default() -> Self {
             Self {
-                description: Ok(Default::default()),
+                api_key_security_scheme: Ok(Default::default()),
+                http_auth_security_scheme: Ok(Default::default()),
+                mtls_security_scheme: Ok(Default::default()),
+                oauth2_security_scheme: Ok(Default::default()),
+                open_id_connect_security_scheme: Ok(Default::default()),
             }
         }
     }
-    impl SecuritySchemeBase {
-        pub fn description<T>(mut self, value: T) -> Self
+    impl SecurityScheme {
+        pub fn api_key_security_scheme<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T: ::std::convert::TryInto<::std::option::Option<super::ApiKeySecurityScheme>>,
             T::Error: ::std::fmt::Display,
         {
-            self.description = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for description: {}", e));
+            self.api_key_security_scheme = value.try_into().map_err(|e| {
+                format!("error converting supplied value for api_key_security_scheme: {e}")
+            });
+            self
+        }
+        pub fn http_auth_security_scheme<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::HttpAuthSecurityScheme>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.http_auth_security_scheme = value.try_into().map_err(|e| {
+                format!("error converting supplied value for http_auth_security_scheme: {e}")
+            });
+            self
+        }
+        pub fn mtls_security_scheme<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::MutualTlsSecurityScheme>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.mtls_security_scheme = value.try_into().map_err(|e| {
+                format!("error converting supplied value for mtls_security_scheme: {e}")
+            });
+            self
+        }
+        pub fn oauth2_security_scheme<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::OAuth2SecurityScheme>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.oauth2_security_scheme = value.try_into().map_err(|e| {
+                format!("error converting supplied value for oauth2_security_scheme: {e}")
+            });
+            self
+        }
+        pub fn open_id_connect_security_scheme<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::OpenIdConnectSecurityScheme>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.open_id_connect_security_scheme = value.try_into().map_err(|e| {
+                format!("error converting supplied value for open_id_connect_security_scheme: {e}")
+            });
             self
         }
     }
-    impl ::std::convert::TryFrom<SecuritySchemeBase> for super::SecuritySchemeBase {
+    impl ::std::convert::TryFrom<SecurityScheme> for super::SecurityScheme {
         type Error = super::error::ConversionError;
         fn try_from(
-            value: SecuritySchemeBase,
+            value: SecurityScheme,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                description: value.description?,
+                api_key_security_scheme: value.api_key_security_scheme?,
+                http_auth_security_scheme: value.http_auth_security_scheme?,
+                mtls_security_scheme: value.mtls_security_scheme?,
+                oauth2_security_scheme: value.oauth2_security_scheme?,
+                open_id_connect_security_scheme: value.open_id_connect_security_scheme?,
             })
         }
     }
-    impl ::std::convert::From<super::SecuritySchemeBase> for SecuritySchemeBase {
-        fn from(value: super::SecuritySchemeBase) -> Self {
+    impl ::std::convert::From<super::SecurityScheme> for SecurityScheme {
+        fn from(value: super::SecurityScheme) -> Self {
             Self {
-                description: Ok(value.description),
+                api_key_security_scheme: Ok(value.api_key_security_scheme),
+                http_auth_security_scheme: Ok(value.http_auth_security_scheme),
+                mtls_security_scheme: Ok(value.mtls_security_scheme),
+                oauth2_security_scheme: Ok(value.oauth2_security_scheme),
+                open_id_connect_security_scheme: Ok(value.open_id_connect_security_scheme),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct SendMessageConfiguration {
+        accepted_output_modes:
+            ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
+        blocking: ::std::result::Result<bool, ::std::string::String>,
+        history_length: ::std::result::Result<::std::option::Option<i32>, ::std::string::String>,
+        push_notification_config: ::std::result::Result<
+            ::std::option::Option<super::PushNotificationConfig>,
+            ::std::string::String,
+        >,
+    }
+    impl ::std::default::Default for SendMessageConfiguration {
+        fn default() -> Self {
+            Self {
+                accepted_output_modes: Ok(Default::default()),
+                blocking: Err("no value supplied for blocking".to_string()),
+                history_length: Ok(Default::default()),
+                push_notification_config: Ok(Default::default()),
+            }
+        }
+    }
+    impl SendMessageConfiguration {
+        pub fn accepted_output_modes<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.accepted_output_modes = value.try_into().map_err(|e| {
+                format!("error converting supplied value for accepted_output_modes: {e}")
+            });
+            self
+        }
+        pub fn blocking<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<bool>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.blocking = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for blocking: {e}"));
+            self
+        }
+        pub fn history_length<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<i32>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.history_length = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for history_length: {e}"));
+            self
+        }
+        pub fn push_notification_config<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::PushNotificationConfig>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.push_notification_config = value.try_into().map_err(|e| {
+                format!("error converting supplied value for push_notification_config: {e}")
+            });
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<SendMessageConfiguration> for super::SendMessageConfiguration {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: SendMessageConfiguration,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                accepted_output_modes: value.accepted_output_modes?,
+                blocking: value.blocking?,
+                history_length: value.history_length?,
+                push_notification_config: value.push_notification_config?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::SendMessageConfiguration> for SendMessageConfiguration {
+        fn from(value: super::SendMessageConfiguration) -> Self {
+            Self {
+                accepted_output_modes: Ok(value.accepted_output_modes),
+                blocking: Ok(value.blocking),
+                history_length: Ok(value.history_length),
+                push_notification_config: Ok(value.push_notification_config),
             }
         }
     }
     #[derive(Clone, Debug)]
     pub struct SendMessageRequest {
-        id: ::std::result::Result<super::SendMessageRequestId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<super::MessageSendParams, ::std::string::String>,
+        configuration: ::std::result::Result<
+            ::std::option::Option<super::SendMessageConfiguration>,
+            ::std::string::String,
+        >,
+        message:
+            ::std::result::Result<::std::option::Option<super::Message>, ::std::string::String>,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for SendMessageRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                configuration: Ok(Default::default()),
+                message: Ok(Default::default()),
+                metadata: Ok(Default::default()),
+                tenant: Err("no value supplied for tenant".to_string()),
             }
         }
     }
     impl SendMessageRequest {
-        pub fn id<T>(mut self, value: T) -> Self
+        pub fn configuration<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::SendMessageRequestId>,
+            T: ::std::convert::TryInto<::std::option::Option<super::SendMessageConfiguration>>,
             T::Error: ::std::fmt::Display,
         {
-            self.id = value
+            self.configuration = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for configuration: {e}"));
             self
         }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn message<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::Message>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.message = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for message: {e}"));
+            self
+        }
+        pub fn metadata<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.metadata = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
+            self
+        }
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn method<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.method = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::MessageSendParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -12364,311 +6414,137 @@ pub mod builder {
             value: SendMessageRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                configuration: value.configuration?,
+                message: value.message?,
+                metadata: value.metadata?,
+                tenant: value.tenant?,
             })
         }
     }
     impl ::std::convert::From<super::SendMessageRequest> for SendMessageRequest {
         fn from(value: super::SendMessageRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
+                configuration: Ok(value.configuration),
+                message: Ok(value.message),
+                metadata: Ok(value.metadata),
+                tenant: Ok(value.tenant),
             }
         }
     }
     #[derive(Clone, Debug)]
-    pub struct SendMessageSuccessResponse {
-        id: ::std::result::Result<super::SendMessageSuccessResponseId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result:
-            ::std::result::Result<super::SendMessageSuccessResponseResult, ::std::string::String>,
+    pub struct SendMessageResponse {
+        message:
+            ::std::result::Result<::std::option::Option<super::Message>, ::std::string::String>,
+        task: ::std::result::Result<::std::option::Option<super::Task>, ::std::string::String>,
     }
-    impl ::std::default::Default for SendMessageSuccessResponse {
+    impl ::std::default::Default for SendMessageResponse {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
+                message: Ok(Default::default()),
+                task: Ok(Default::default()),
             }
         }
     }
-    impl SendMessageSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
+    impl SendMessageResponse {
+        pub fn message<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::SendMessageSuccessResponseId>,
+            T: ::std::convert::TryInto<::std::option::Option<super::Message>>,
             T::Error: ::std::fmt::Display,
         {
-            self.id = value
+            self.message = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for message: {e}"));
             self
         }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn task<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::string::String>,
+            T: ::std::convert::TryInto<::std::option::Option<super::Task>>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.task = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::SendMessageSuccessResponseResult>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for task: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<SendMessageSuccessResponse> for super::SendMessageSuccessResponse {
+    impl ::std::convert::TryFrom<SendMessageResponse> for super::SendMessageResponse {
         type Error = super::error::ConversionError;
         fn try_from(
-            value: SendMessageSuccessResponse,
+            value: SendMessageResponse,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
+                message: value.message?,
+                task: value.task?,
             })
         }
     }
-    impl ::std::convert::From<super::SendMessageSuccessResponse> for SendMessageSuccessResponse {
-        fn from(value: super::SendMessageSuccessResponse) -> Self {
+    impl ::std::convert::From<super::SendMessageResponse> for SendMessageResponse {
+        fn from(value: super::SendMessageResponse) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct SendStreamingMessageRequest {
-        id: ::std::result::Result<super::SendStreamingMessageRequestId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<super::MessageSendParams, ::std::string::String>,
-    }
-    impl ::std::default::Default for SendStreamingMessageRequest {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
-            }
-        }
-    }
-    impl SendStreamingMessageRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::SendStreamingMessageRequestId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn method<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.method = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::MessageSendParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<SendStreamingMessageRequest> for super::SendStreamingMessageRequest {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: SendStreamingMessageRequest,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::SendStreamingMessageRequest> for SendStreamingMessageRequest {
-        fn from(value: super::SendStreamingMessageRequest) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct SendStreamingMessageSuccessResponse {
-        id: ::std::result::Result<
-            super::SendStreamingMessageSuccessResponseId,
-            ::std::string::String,
-        >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<
-            super::SendStreamingMessageSuccessResponseResult,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for SendStreamingMessageSuccessResponse {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
-            }
-        }
-    }
-    impl SendStreamingMessageSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::SendStreamingMessageSuccessResponseId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn result<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::SendStreamingMessageSuccessResponseResult>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.result = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<SendStreamingMessageSuccessResponse>
-        for super::SendStreamingMessageSuccessResponse
-    {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: SendStreamingMessageSuccessResponse,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::SendStreamingMessageSuccessResponse>
-        for SendStreamingMessageSuccessResponse
-    {
-        fn from(value: super::SendStreamingMessageSuccessResponse) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
+                message: Ok(value.message),
+                task: Ok(value.task),
             }
         }
     }
     #[derive(Clone, Debug)]
     pub struct SetTaskPushNotificationConfigRequest {
-        id: ::std::result::Result<
-            super::SetTaskPushNotificationConfigRequestId,
+        config: ::std::result::Result<super::TaskPushNotificationConfig, ::std::string::String>,
+        config_id: ::std::result::Result<::std::string::String, ::std::string::String>,
+        parent: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<
+            ::std::option::Option<::std::string::String>,
             ::std::string::String,
         >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<super::TaskPushNotificationConfig, ::std::string::String>,
     }
     impl ::std::default::Default for SetTaskPushNotificationConfigRequest {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
+                config: Err("no value supplied for config".to_string()),
+                config_id: Err("no value supplied for config_id".to_string()),
+                parent: Err("no value supplied for parent".to_string()),
+                tenant: Ok(Default::default()),
             }
         }
     }
     impl SetTaskPushNotificationConfigRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::SetTaskPushNotificationConfigRequestId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn method<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.method = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
+        pub fn config<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<super::TaskPushNotificationConfig>,
             T::Error: ::std::fmt::Display,
         {
-            self.params = value
+            self.config = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
+                .map_err(|e| format!("error converting supplied value for config: {e}"));
+            self
+        }
+        pub fn config_id<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.config_id = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for config_id: {e}"));
+            self
+        }
+        pub fn parent<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.parent = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for parent: {e}"));
+            self
+        }
+        pub fn tenant<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.tenant = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
@@ -12680,10 +6556,10 @@ pub mod builder {
             value: SetTaskPushNotificationConfigRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
+                config: value.config?,
+                config_id: value.config_id?,
+                parent: value.parent?,
+                tenant: value.tenant?,
             })
         }
     }
@@ -12692,85 +6568,191 @@ pub mod builder {
     {
         fn from(value: super::SetTaskPushNotificationConfigRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
+                config: Ok(value.config),
+                config_id: Ok(value.config_id),
+                parent: Ok(value.parent),
+                tenant: Ok(value.tenant),
             }
         }
     }
     #[derive(Clone, Debug)]
-    pub struct SetTaskPushNotificationConfigSuccessResponse {
-        id: ::std::result::Result<
-            super::SetTaskPushNotificationConfigSuccessResponseId,
+    pub struct StreamResponse {
+        artifact_update: ::std::result::Result<
+            ::std::option::Option<super::TaskArtifactUpdateEvent>,
             ::std::string::String,
         >,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        result: ::std::result::Result<super::TaskPushNotificationConfig, ::std::string::String>,
+        message:
+            ::std::result::Result<::std::option::Option<super::Message>, ::std::string::String>,
+        status_update: ::std::result::Result<
+            ::std::option::Option<super::TaskStatusUpdateEvent>,
+            ::std::string::String,
+        >,
+        task: ::std::result::Result<::std::option::Option<super::Task>, ::std::string::String>,
     }
-    impl ::std::default::Default for SetTaskPushNotificationConfigSuccessResponse {
+    impl ::std::default::Default for StreamResponse {
         fn default() -> Self {
             Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                result: Err("no value supplied for result".to_string()),
+                artifact_update: Ok(Default::default()),
+                message: Ok(Default::default()),
+                status_update: Ok(Default::default()),
+                task: Ok(Default::default()),
             }
         }
     }
-    impl SetTaskPushNotificationConfigSuccessResponse {
-        pub fn id<T>(mut self, value: T) -> Self
+    impl StreamResponse {
+        pub fn artifact_update<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::SetTaskPushNotificationConfigSuccessResponseId>,
+            T: ::std::convert::TryInto<::std::option::Option<super::TaskArtifactUpdateEvent>>,
             T::Error: ::std::fmt::Display,
         {
-            self.id = value
+            self.artifact_update = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
+                .map_err(|e| format!("error converting supplied value for artifact_update: {e}"));
             self
         }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
+        pub fn message<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::Message>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.message = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for message: {e}"));
+            self
+        }
+        pub fn status_update<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::TaskStatusUpdateEvent>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.status_update = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for status_update: {e}"));
+            self
+        }
+        pub fn task<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::option::Option<super::Task>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for task: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<StreamResponse> for super::StreamResponse {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: StreamResponse,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self {
+                artifact_update: value.artifact_update?,
+                message: value.message?,
+                status_update: value.status_update?,
+                task: value.task?,
+            })
+        }
+    }
+    impl ::std::convert::From<super::StreamResponse> for StreamResponse {
+        fn from(value: super::StreamResponse) -> Self {
+            Self {
+                artifact_update: Ok(value.artifact_update),
+                message: Ok(value.message),
+                status_update: Ok(value.status_update),
+                task: Ok(value.task),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct StringList {
+        list: ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
+    }
+    impl ::std::default::Default for StringList {
+        fn default() -> Self {
+            Self {
+                list: Ok(Default::default()),
+            }
+        }
+    }
+    impl StringList {
+        pub fn list<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.list = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for list: {e}"));
+            self
+        }
+    }
+    impl ::std::convert::TryFrom<StringList> for super::StringList {
+        type Error = super::error::ConversionError;
+        fn try_from(
+            value: StringList,
+        ) -> ::std::result::Result<Self, super::error::ConversionError> {
+            Ok(Self { list: value.list? })
+        }
+    }
+    impl ::std::convert::From<super::StringList> for StringList {
+        fn from(value: super::StringList) -> Self {
+            Self {
+                list: Ok(value.list),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct SubscribeToTaskRequest {
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
+        tenant: ::std::result::Result<::std::string::String, ::std::string::String>,
+    }
+    impl ::std::default::Default for SubscribeToTaskRequest {
+        fn default() -> Self {
+            Self {
+                name: Err("no value supplied for name".to_string()),
+                tenant: Err("no value supplied for tenant".to_string()),
+            }
+        }
+    }
+    impl SubscribeToTaskRequest {
+        pub fn name<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.jsonrpc = value
+            self.name = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
             self
         }
-        pub fn result<T>(mut self, value: T) -> Self
+        pub fn tenant<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<super::TaskPushNotificationConfig>,
+            T: ::std::convert::TryInto<::std::string::String>,
             T::Error: ::std::fmt::Display,
         {
-            self.result = value
+            self.tenant = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for result: {}", e));
+                .map_err(|e| format!("error converting supplied value for tenant: {e}"));
             self
         }
     }
-    impl ::std::convert::TryFrom<SetTaskPushNotificationConfigSuccessResponse>
-        for super::SetTaskPushNotificationConfigSuccessResponse
-    {
+    impl ::std::convert::TryFrom<SubscribeToTaskRequest> for super::SubscribeToTaskRequest {
         type Error = super::error::ConversionError;
         fn try_from(
-            value: SetTaskPushNotificationConfigSuccessResponse,
+            value: SubscribeToTaskRequest,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                result: value.result?,
+                name: value.name?,
+                tenant: value.tenant?,
             })
         }
     }
-    impl ::std::convert::From<super::SetTaskPushNotificationConfigSuccessResponse>
-        for SetTaskPushNotificationConfigSuccessResponse
-    {
-        fn from(value: super::SetTaskPushNotificationConfigSuccessResponse) -> Self {
+    impl ::std::convert::From<super::SubscribeToTaskRequest> for SubscribeToTaskRequest {
+        fn from(value: super::SubscribeToTaskRequest) -> Self {
             Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                result: Ok(value.result),
+                name: Ok(value.name),
+                tenant: Ok(value.tenant),
             }
         }
     }
@@ -12780,11 +6762,8 @@ pub mod builder {
         context_id: ::std::result::Result<::std::string::String, ::std::string::String>,
         history: ::std::result::Result<::std::vec::Vec<super::Message>, ::std::string::String>,
         id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
         status: ::std::result::Result<super::TaskStatus, ::std::string::String>,
     }
     impl ::std::default::Default for Task {
@@ -12794,7 +6773,6 @@ pub mod builder {
                 context_id: Err("no value supplied for context_id".to_string()),
                 history: Ok(Default::default()),
                 id: Err("no value supplied for id".to_string()),
-                kind: Err("no value supplied for kind".to_string()),
                 metadata: Ok(Default::default()),
                 status: Err("no value supplied for status".to_string()),
             }
@@ -12808,7 +6786,7 @@ pub mod builder {
         {
             self.artifacts = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for artifacts: {}", e));
+                .map_err(|e| format!("error converting supplied value for artifacts: {e}"));
             self
         }
         pub fn context_id<T>(mut self, value: T) -> Self
@@ -12818,7 +6796,7 @@ pub mod builder {
         {
             self.context_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for context_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for context_id: {e}"));
             self
         }
         pub fn history<T>(mut self, value: T) -> Self
@@ -12828,7 +6806,7 @@ pub mod builder {
         {
             self.history = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for history: {}", e));
+                .map_err(|e| format!("error converting supplied value for history: {e}"));
             self
         }
         pub fn id<T>(mut self, value: T) -> Self
@@ -12838,29 +6816,17 @@ pub mod builder {
         {
             self.id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn kind<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.kind = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                .map_err(|e| format!("error converting supplied value for id: {e}"));
             self
         }
         pub fn metadata<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.metadata = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
             self
         }
         pub fn status<T>(mut self, value: T) -> Self
@@ -12870,7 +6836,7 @@ pub mod builder {
         {
             self.status = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for status: {}", e));
+                .map_err(|e| format!("error converting supplied value for status: {e}"));
             self
         }
     }
@@ -12882,7 +6848,6 @@ pub mod builder {
                 context_id: value.context_id?,
                 history: value.history?,
                 id: value.id?,
-                kind: value.kind?,
                 metadata: value.metadata?,
                 status: value.status?,
             })
@@ -12895,7 +6860,6 @@ pub mod builder {
                 context_id: Ok(value.context_id),
                 history: Ok(value.history),
                 id: Ok(value.id),
-                kind: Ok(value.kind),
                 metadata: Ok(value.metadata),
                 status: Ok(value.status),
             }
@@ -12906,12 +6870,9 @@ pub mod builder {
         append: ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
         artifact: ::std::result::Result<super::Artifact, ::std::string::String>,
         context_id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
         last_chunk: ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
         task_id: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for TaskArtifactUpdateEvent {
@@ -12920,7 +6881,6 @@ pub mod builder {
                 append: Ok(Default::default()),
                 artifact: Err("no value supplied for artifact".to_string()),
                 context_id: Err("no value supplied for context_id".to_string()),
-                kind: Err("no value supplied for kind".to_string()),
                 last_chunk: Ok(Default::default()),
                 metadata: Ok(Default::default()),
                 task_id: Err("no value supplied for task_id".to_string()),
@@ -12935,7 +6895,7 @@ pub mod builder {
         {
             self.append = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for append: {}", e));
+                .map_err(|e| format!("error converting supplied value for append: {e}"));
             self
         }
         pub fn artifact<T>(mut self, value: T) -> Self
@@ -12945,7 +6905,7 @@ pub mod builder {
         {
             self.artifact = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for artifact: {}", e));
+                .map_err(|e| format!("error converting supplied value for artifact: {e}"));
             self
         }
         pub fn context_id<T>(mut self, value: T) -> Self
@@ -12955,17 +6915,7 @@ pub mod builder {
         {
             self.context_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for context_id: {}", e));
-            self
-        }
-        pub fn kind<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.kind = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                .map_err(|e| format!("error converting supplied value for context_id: {e}"));
             self
         }
         pub fn last_chunk<T>(mut self, value: T) -> Self
@@ -12975,19 +6925,17 @@ pub mod builder {
         {
             self.last_chunk = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for last_chunk: {}", e));
+                .map_err(|e| format!("error converting supplied value for last_chunk: {e}"));
             self
         }
         pub fn metadata<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.metadata = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
             self
         }
         pub fn task_id<T>(mut self, value: T) -> Self
@@ -12997,7 +6945,7 @@ pub mod builder {
         {
             self.task_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for task_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for task_id: {e}"));
             self
         }
     }
@@ -13010,7 +6958,6 @@ pub mod builder {
                 append: value.append?,
                 artifact: value.artifact?,
                 context_id: value.context_id?,
-                kind: value.kind?,
                 last_chunk: value.last_chunk?,
                 metadata: value.metadata?,
                 task_id: value.task_id?,
@@ -13023,7 +6970,6 @@ pub mod builder {
                 append: Ok(value.append),
                 artifact: Ok(value.artifact),
                 context_id: Ok(value.context_id),
-                kind: Ok(value.kind),
                 last_chunk: Ok(value.last_chunk),
                 metadata: Ok(value.metadata),
                 task_id: Ok(value.task_id),
@@ -13031,244 +6977,40 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    pub struct TaskIdParams {
-        id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for TaskIdParams {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                metadata: Ok(Default::default()),
-            }
-        }
-    }
-    impl TaskIdParams {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<TaskIdParams> for super::TaskIdParams {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: TaskIdParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                metadata: value.metadata?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::TaskIdParams> for TaskIdParams {
-        fn from(value: super::TaskIdParams) -> Self {
-            Self {
-                id: Ok(value.id),
-                metadata: Ok(value.metadata),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct TaskNotCancelableError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for TaskNotCancelableError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl TaskNotCancelableError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<TaskNotCancelableError> for super::TaskNotCancelableError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: TaskNotCancelableError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::TaskNotCancelableError> for TaskNotCancelableError {
-        fn from(value: super::TaskNotCancelableError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct TaskNotFoundError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for TaskNotFoundError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl TaskNotFoundError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<TaskNotFoundError> for super::TaskNotFoundError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: TaskNotFoundError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::TaskNotFoundError> for TaskNotFoundError {
-        fn from(value: super::TaskNotFoundError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
     pub struct TaskPushNotificationConfig {
+        name: ::std::result::Result<::std::string::String, ::std::string::String>,
         push_notification_config:
             ::std::result::Result<super::PushNotificationConfig, ::std::string::String>,
-        task_id: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
     impl ::std::default::Default for TaskPushNotificationConfig {
         fn default() -> Self {
             Self {
+                name: Err("no value supplied for name".to_string()),
                 push_notification_config: Err(
                     "no value supplied for push_notification_config".to_string()
                 ),
-                task_id: Err("no value supplied for task_id".to_string()),
             }
         }
     }
     impl TaskPushNotificationConfig {
+        pub fn name<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.name = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for name: {e}"));
+            self
+        }
         pub fn push_notification_config<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<super::PushNotificationConfig>,
             T::Error: ::std::fmt::Display,
         {
             self.push_notification_config = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for push_notification_config: {}",
-                    e
-                )
+                format!("error converting supplied value for push_notification_config: {e}")
             });
-            self
-        }
-        pub fn task_id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.task_id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for task_id: {}", e));
             self
         }
     }
@@ -13278,171 +7020,16 @@ pub mod builder {
             value: TaskPushNotificationConfig,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
+                name: value.name?,
                 push_notification_config: value.push_notification_config?,
-                task_id: value.task_id?,
             })
         }
     }
     impl ::std::convert::From<super::TaskPushNotificationConfig> for TaskPushNotificationConfig {
         fn from(value: super::TaskPushNotificationConfig) -> Self {
             Self {
+                name: Ok(value.name),
                 push_notification_config: Ok(value.push_notification_config),
-                task_id: Ok(value.task_id),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct TaskQueryParams {
-        history_length: ::std::result::Result<::std::option::Option<i64>, ::std::string::String>,
-        id: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-    }
-    impl ::std::default::Default for TaskQueryParams {
-        fn default() -> Self {
-            Self {
-                history_length: Ok(Default::default()),
-                id: Err("no value supplied for id".to_string()),
-                metadata: Ok(Default::default()),
-            }
-        }
-    }
-    impl TaskQueryParams {
-        pub fn history_length<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<i64>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.history_length = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for history_length: {}", e));
-            self
-        }
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<TaskQueryParams> for super::TaskQueryParams {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: TaskQueryParams,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                history_length: value.history_length?,
-                id: value.id?,
-                metadata: value.metadata?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::TaskQueryParams> for TaskQueryParams {
-        fn from(value: super::TaskQueryParams) -> Self {
-            Self {
-                history_length: Ok(value.history_length),
-                id: Ok(value.id),
-                metadata: Ok(value.metadata),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct TaskResubscriptionRequest {
-        id: ::std::result::Result<super::TaskResubscriptionRequestId, ::std::string::String>,
-        jsonrpc: ::std::result::Result<::std::string::String, ::std::string::String>,
-        method: ::std::result::Result<::std::string::String, ::std::string::String>,
-        params: ::std::result::Result<super::TaskIdParams, ::std::string::String>,
-    }
-    impl ::std::default::Default for TaskResubscriptionRequest {
-        fn default() -> Self {
-            Self {
-                id: Err("no value supplied for id".to_string()),
-                jsonrpc: Err("no value supplied for jsonrpc".to_string()),
-                method: Err("no value supplied for method".to_string()),
-                params: Err("no value supplied for params".to_string()),
-            }
-        }
-    }
-    impl TaskResubscriptionRequest {
-        pub fn id<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::TaskResubscriptionRequestId>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.id = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for id: {}", e));
-            self
-        }
-        pub fn jsonrpc<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.jsonrpc = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for jsonrpc: {}", e));
-            self
-        }
-        pub fn method<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.method = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for method: {}", e));
-            self
-        }
-        pub fn params<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<super::TaskIdParams>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.params = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for params: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<TaskResubscriptionRequest> for super::TaskResubscriptionRequest {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: TaskResubscriptionRequest,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                id: value.id?,
-                jsonrpc: value.jsonrpc?,
-                method: value.method?,
-                params: value.params?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::TaskResubscriptionRequest> for TaskResubscriptionRequest {
-        fn from(value: super::TaskResubscriptionRequest) -> Self {
-            Self {
-                id: Ok(value.id),
-                jsonrpc: Ok(value.jsonrpc),
-                method: Ok(value.method),
-                params: Ok(value.params),
             }
         }
     }
@@ -13451,10 +7038,8 @@ pub mod builder {
         message:
             ::std::result::Result<::std::option::Option<super::Message>, ::std::string::String>,
         state: ::std::result::Result<super::TaskState, ::std::string::String>,
-        timestamp: ::std::result::Result<
-            ::std::option::Option<::std::string::String>,
-            ::std::string::String,
-        >,
+        timestamp:
+            ::std::result::Result<::std::option::Option<super::Timestamp>, ::std::string::String>,
     }
     impl ::std::default::Default for TaskStatus {
         fn default() -> Self {
@@ -13473,7 +7058,7 @@ pub mod builder {
         {
             self.message = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
+                .map_err(|e| format!("error converting supplied value for message: {e}"));
             self
         }
         pub fn state<T>(mut self, value: T) -> Self
@@ -13483,17 +7068,17 @@ pub mod builder {
         {
             self.state = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for state: {}", e));
+                .map_err(|e| format!("error converting supplied value for state: {e}"));
             self
         }
         pub fn timestamp<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+            T: ::std::convert::TryInto<::std::option::Option<super::Timestamp>>,
             T::Error: ::std::fmt::Display,
         {
             self.timestamp = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for timestamp: {}", e));
+                .map_err(|e| format!("error converting supplied value for timestamp: {e}"));
             self
         }
     }
@@ -13522,11 +7107,8 @@ pub mod builder {
     pub struct TaskStatusUpdateEvent {
         context_id: ::std::result::Result<::std::string::String, ::std::string::String>,
         final_: ::std::result::Result<bool, ::std::string::String>,
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
+        metadata:
+            ::std::result::Result<::std::option::Option<super::Struct>, ::std::string::String>,
         status: ::std::result::Result<super::TaskStatus, ::std::string::String>,
         task_id: ::std::result::Result<::std::string::String, ::std::string::String>,
     }
@@ -13535,7 +7117,6 @@ pub mod builder {
             Self {
                 context_id: Err("no value supplied for context_id".to_string()),
                 final_: Err("no value supplied for final_".to_string()),
-                kind: Err("no value supplied for kind".to_string()),
                 metadata: Ok(Default::default()),
                 status: Err("no value supplied for status".to_string()),
                 task_id: Err("no value supplied for task_id".to_string()),
@@ -13550,7 +7131,7 @@ pub mod builder {
         {
             self.context_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for context_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for context_id: {e}"));
             self
         }
         pub fn final_<T>(mut self, value: T) -> Self
@@ -13560,29 +7141,17 @@ pub mod builder {
         {
             self.final_ = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for final_: {}", e));
-            self
-        }
-        pub fn kind<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.kind = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
+                .map_err(|e| format!("error converting supplied value for final_: {e}"));
             self
         }
         pub fn metadata<T>(mut self, value: T) -> Self
         where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
+            T: ::std::convert::TryInto<::std::option::Option<super::Struct>>,
             T::Error: ::std::fmt::Display,
         {
             self.metadata = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
+                .map_err(|e| format!("error converting supplied value for metadata: {e}"));
             self
         }
         pub fn status<T>(mut self, value: T) -> Self
@@ -13592,7 +7161,7 @@ pub mod builder {
         {
             self.status = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for status: {}", e));
+                .map_err(|e| format!("error converting supplied value for status: {e}"));
             self
         }
         pub fn task_id<T>(mut self, value: T) -> Self
@@ -13602,7 +7171,7 @@ pub mod builder {
         {
             self.task_id = value
                 .try_into()
-                .map_err(|e| format!("error converting supplied value for task_id: {}", e));
+                .map_err(|e| format!("error converting supplied value for task_id: {e}"));
             self
         }
     }
@@ -13614,7 +7183,6 @@ pub mod builder {
             Ok(Self {
                 context_id: value.context_id?,
                 final_: value.final_?,
-                kind: value.kind?,
                 metadata: value.metadata?,
                 status: value.status?,
                 task_id: value.task_id?,
@@ -13626,159 +7194,10 @@ pub mod builder {
             Self {
                 context_id: Ok(value.context_id),
                 final_: Ok(value.final_),
-                kind: Ok(value.kind),
                 metadata: Ok(value.metadata),
                 status: Ok(value.status),
                 task_id: Ok(value.task_id),
             }
         }
-    }
-    #[derive(Clone, Debug)]
-    pub struct TextPart {
-        kind: ::std::result::Result<::std::string::String, ::std::string::String>,
-        metadata: ::std::result::Result<
-            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-            ::std::string::String,
-        >,
-        text: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for TextPart {
-        fn default() -> Self {
-            Self {
-                kind: Err("no value supplied for kind".to_string()),
-                metadata: Ok(Default::default()),
-                text: Err("no value supplied for text".to_string()),
-            }
-        }
-    }
-    impl TextPart {
-        pub fn kind<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.kind = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for kind: {}", e));
-            self
-        }
-        pub fn metadata<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<
-                    ::serde_json::Map<::std::string::String, ::serde_json::Value>,
-                >,
-            T::Error: ::std::fmt::Display,
-        {
-            self.metadata = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for metadata: {}", e));
-            self
-        }
-        pub fn text<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.text = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for text: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<TextPart> for super::TextPart {
-        type Error = super::error::ConversionError;
-        fn try_from(value: TextPart) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                kind: value.kind?,
-                metadata: value.metadata?,
-                text: value.text?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::TextPart> for TextPart {
-        fn from(value: super::TextPart) -> Self {
-            Self {
-                kind: Ok(value.kind),
-                metadata: Ok(value.metadata),
-                text: Ok(value.text),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
-    pub struct UnsupportedOperationError {
-        code: ::std::result::Result<i64, ::std::string::String>,
-        data: ::std::result::Result<
-            ::std::option::Option<::serde_json::Value>,
-            ::std::string::String,
-        >,
-        message: ::std::result::Result<::std::string::String, ::std::string::String>,
-    }
-    impl ::std::default::Default for UnsupportedOperationError {
-        fn default() -> Self {
-            Self {
-                code: Err("no value supplied for code".to_string()),
-                data: Ok(Default::default()),
-                message: Err("no value supplied for message".to_string()),
-            }
-        }
-    }
-    impl UnsupportedOperationError {
-        pub fn code<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<i64>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.code = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for code: {}", e));
-            self
-        }
-        pub fn data<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::option::Option<::serde_json::Value>>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.data = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for data: {}", e));
-            self
-        }
-        pub fn message<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<::std::string::String>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.message = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for message: {}", e));
-            self
-        }
-    }
-    impl ::std::convert::TryFrom<UnsupportedOperationError> for super::UnsupportedOperationError {
-        type Error = super::error::ConversionError;
-        fn try_from(
-            value: UnsupportedOperationError,
-        ) -> ::std::result::Result<Self, super::error::ConversionError> {
-            Ok(Self {
-                code: value.code?,
-                data: value.data?,
-                message: value.message?,
-            })
-        }
-    }
-    impl ::std::convert::From<super::UnsupportedOperationError> for UnsupportedOperationError {
-        fn from(value: super::UnsupportedOperationError) -> Self {
-            Self {
-                code: Ok(value.code),
-                data: Ok(value.data),
-                message: Ok(value.message),
-            }
-        }
-    }
-}
-#[doc = r" Generation of default values for serde."]
-pub mod defaults {
-    pub(super) fn agent_card_preferred_transport() -> ::std::string::String {
-        "JSONRPC".to_string()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,24 +11,29 @@ pub use server::{A2AServer, A2AServerBuilder, Agent, AgentBuilder, AgentCardOver
 mod tests {
     #[test]
     fn test_a2a_types_module_exists() {
-        use crate::a2a_types::JsonrpcMessage;
-        let _type_exists = std::mem::size_of::<JsonrpcMessage>();
+        use crate::a2a_types::Message;
+        let _type_exists = std::mem::size_of::<Message>();
     }
 
     #[test]
     fn test_a2a_types_serialization() {
         use crate::a2a_types::*;
 
-        let message = JsonrpcMessage {
-            jsonrpc: "2.0".to_string(),
-            id: Some(JsonrpcMessageId::String("test-id".to_string())),
+        let message = Message {
+            context_id: None,
+            extensions: Vec::new(),
+            message_id: "test-id".to_string(),
+            metadata: None,
+            parts: Vec::new(),
+            reference_task_ids: Vec::new(),
+            role: Role::RoleUser,
+            task_id: None,
         };
 
         let serialized = serde_json::to_string(&message).expect("Should serialize");
-        assert!(serialized.contains("\"jsonrpc\":\"2.0\""));
-        assert!(serialized.contains("\"id\":\"test-id\""));
+        assert!(serialized.contains("\"messageId\":\"test-id\""));
+        assert!(serialized.contains("\"role\":\"ROLE_USER\""));
 
-        let _deserialized: JsonrpcMessage =
-            serde_json::from_str(&serialized).expect("Should deserialize");
+        let _deserialized: Message = serde_json::from_str(&serialized).expect("Should deserialize");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -299,8 +299,8 @@ impl A2AServerBuilder {
                     card.version = version;
                 }
                 if let Some(url) = overrides.url {
-                    info!("Overriding agent card URL: {} -> {}", card.url, url);
-                    card.url = url;
+                    info!("Overriding agent card URL: {:?} -> {}", card.url, url);
+                    card.url = Some(url);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Regenerates `src/a2a_types.rs` from the canonical A2A schema at SHA `0621adef1c2351d3ee389f7b68d87b1f93de5a73` so the vendored `schema.json` / `schema.yaml` and the generated Rust types are back in sync with `inference-gateway/schemas`.
- Adds the missing top-level types called out in the issue: `GetExtendedAgentCardRequest`, `ListTasksRequest`, `ListTasksResponse`, `MutualTlsSecurityScheme`, `StreamResponse`, `SubscribeToTaskRequest`, `SendMessageConfiguration`, `AuthenticationInfo`.
- Drops the obsolete ones: `SendStreamingMessageRequest` / `Response` / `SuccessResponse`, `MessageSendParams`, `MessageSendConfiguration`, `TaskResubscriptionRequest`.
- Adapts downstream call sites: `AgentCard.url` is now `Option<String>` (server override), `AgentCard.preferred_transport` is `Option<String>` (client example), and the `lib.rs` ser/de smoke test now exercises `Message` instead of the removed `JsonrpcMessage`.
- Adds `regress = "0.11.1"` to `Cargo.toml` — typify now emits regex-based pattern validation that depends on it.
- Replaces the GNU-only `sed -i '1i\…'` snippet in `Taskfile.yml`'s `a2a:generate-types` with a portable here-doc so the task runs on both BSD (macOS) and GNU coreutils.

## Acceptance criteria

- [x] Run the project's codegen pipeline (`task a2a:generate-types`) against the freshly synced `schema.yaml` to regenerate `src/a2a_types.rs` end-to-end.
- [x] All struct/enum names listed under "missing" in the issue appear in the regenerated file.
- [x] All struct/enum names listed under "should be dropped" no longer appear in the regenerated file.
- [x] `cargo build` and `cargo test` pass; `src/server.rs`, `src/client.rs`, `examples/`, `tests/` updated where renames/shape changes required it.
- [x] `cargo fmt -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

Closes #14 
