### PR TITLE
feat(protocol): Implement tasks/resubscribe and agent/getAuthenticatedExtendedCard

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,10 +555,12 @@ binary per method.
 | `tasks/get`                                   | `get_task`                                  | `GetTaskRequest`                              | `Task`                                   |
 | `tasks/list`                                  | `list_tasks`                                | `ListTasksRequest`                            | `ListTasksResponse`                      |
 | `tasks/cancel`                                | `cancel_task`                               | `CancelTaskRequest`                           | `Task`                                   |
+| `tasks/resubscribe`                           | `resubscribe_task`                          | `SubscribeToTaskRequest`                      | `Stream<StreamResponse>` (SSE)           |
 | `tasks/pushNotificationConfig/set`            | `set_task_push_notification_config`         | `SetTaskPushNotificationConfigRequest`        | `TaskPushNotificationConfig`             |
 | `tasks/pushNotificationConfig/get`            | `get_task_push_notification_config`         | `GetTaskPushNotificationConfigRequest`        | `TaskPushNotificationConfig`             |
 | `tasks/pushNotificationConfig/list`           | `list_task_push_notification_configs`       | `ListTaskPushNotificationConfigRequest`       | `ListTaskPushNotificationConfigResponse` |
 | `tasks/pushNotificationConfig/delete`         | `delete_task_push_notification_config`      | `DeleteTaskPushNotificationConfigRequest`     | `serde_json::Value`                      |
+| `agent/getAuthenticatedExtendedCard`          | `get_authenticated_extended_card`           | `GetExtendedAgentCardRequest`                 | `AgentCard`                              |
 
 ###### `message/send`
 
@@ -647,6 +649,37 @@ let cancelled = client
     .await?;
 ```
 
+###### `tasks/resubscribe`
+
+Re-attach to an already-running task and stream subsequent state
+transitions over SSE. The first event carries a snapshot of the task at
+the current status; later events are `TaskStatusUpdateEvent` deltas. The
+stream terminates after the server emits an event with `final: true`.
+
+```rust
+use futures::StreamExt;
+use inference_gateway_adk::a2a_types::SubscribeToTaskRequest;
+
+let mut stream = Box::pin(
+    client
+        .resubscribe_task(SubscribeToTaskRequest {
+            name: format!("tasks/{task_id}"),
+            tenant: "example".to_string(),
+        })
+        .await?,
+);
+
+while let Some(event) = stream.next().await {
+    let event = event?;
+    if let Some(update) = event.status_update.as_ref() {
+        println!("task is now {:?}", update.status.state);
+        if update.final_ {
+            break;
+        }
+    }
+}
+```
+
 ###### `tasks/pushNotificationConfig/set`
 
 ```rust
@@ -711,6 +744,24 @@ use inference_gateway_adk::a2a_types::DeleteTaskPushNotificationConfigRequest;
 client
     .delete_task_push_notification_config(DeleteTaskPushNotificationConfigRequest {
         name: name.clone(),
+        tenant: "example".to_string(),
+    })
+    .await?;
+```
+
+###### `agent/getAuthenticatedExtendedCard`
+
+Fetch the authenticated extended [`AgentCard`] for the calling tenant.
+The server only honours the request when the agent card it serves at
+`/.well-known/agent.json` advertises `supportsExtendedAgentCard: true`;
+otherwise the call surfaces a JSON-RPC `METHOD_NOT_FOUND` error so the
+client can fall back to the unauthenticated card.
+
+```rust
+use inference_gateway_adk::a2a_types::GetExtendedAgentCardRequest;
+
+let card = client
+    .get_authenticated_extended_card(GetExtendedAgentCardRequest {
         tenant: "example".to_string(),
     })
     .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -328,12 +328,6 @@ impl A2AClient {
             return Err(anyhow!("{method} failed: HTTP {status}: {body}"));
         }
 
-        // If the server responded with a JSON-RPC error envelope (which it
-        // does for validation / not-found errors that happen before the SSE
-        // stream begins), the content type will be JSON rather than
-        // `text/event-stream`. Inspect the content type and unwrap the
-        // error eagerly so callers don't have to fish it out of the SSE
-        // stream.
         let content_type = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,10 @@
 use crate::a2a_types::{
     AgentCard, CancelTaskRequest, DeleteTaskPushNotificationConfigRequest,
-    GetTaskPushNotificationConfigRequest, GetTaskRequest, ListTaskPushNotificationConfigRequest,
-    ListTaskPushNotificationConfigResponse, ListTasksRequest, ListTasksResponse,
-    SendMessageRequest, SendMessageResponse, SetTaskPushNotificationConfigRequest, StreamResponse,
-    Task, TaskPushNotificationConfig, TaskState,
+    GetExtendedAgentCardRequest, GetTaskPushNotificationConfigRequest, GetTaskRequest,
+    ListTaskPushNotificationConfigRequest, ListTaskPushNotificationConfigResponse,
+    ListTasksRequest, ListTasksResponse, SendMessageRequest, SendMessageResponse,
+    SetTaskPushNotificationConfigRequest, StreamResponse, SubscribeToTaskRequest, Task,
+    TaskPushNotificationConfig, TaskState,
 };
 use crate::config::ClientConfig;
 use anyhow::{Result, anyhow};
@@ -155,69 +156,22 @@ impl A2AClient {
         &self,
         params: SendMessageRequest,
     ) -> Result<impl Stream<Item = Result<StreamResponse>> + Send + 'static> {
-        let envelope = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": Uuid::new_v4().to_string(),
-            "method": "message/stream",
-            "params": serde_json::to_value(params)
-                .map_err(|e| anyhow!("failed to serialize stream params: {e}"))?,
-        });
+        self.call_streaming("message/stream", params).await
+    }
 
-        let url = format!("{}/a2a", self.base_url);
-        let response = self
-            .http_client
-            .post(&url)
-            .header("Accept", "text/event-stream")
-            .json(&envelope)
-            .send()
-            .await
-            .map_err(|e| anyhow!("message/stream request failed: {e}"))?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!("message/stream failed: HTTP {status}: {body}"));
-        }
-
-        let event_stream = response.bytes_stream().eventsource();
-
-        let stream = event_stream.filter_map(|event| async move {
-            match event {
-                Ok(event) => {
-                    if event.data.is_empty() {
-                        return None;
-                    }
-                    let parsed: Value = match serde_json::from_str(&event.data) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            return Some(Err(anyhow!(
-                                "failed to parse SSE event as JSON: {e}: {data}",
-                                data = event.data
-                            )));
-                        }
-                    };
-                    if let Some(err) = parsed.get("error") {
-                        return Some(Err(anyhow!("JSON-RPC error in stream: {err}")));
-                    }
-                    let result = match parsed.get("result").cloned() {
-                        Some(v) => v,
-                        None => {
-                            return Some(Err(anyhow!(
-                                "SSE event missing `result`: {data}",
-                                data = event.data
-                            )));
-                        }
-                    };
-                    match serde_json::from_value::<StreamResponse>(result) {
-                        Ok(r) => Some(Ok(r)),
-                        Err(e) => Some(Err(anyhow!("failed to decode StreamResponse: {e}"))),
-                    }
-                }
-                Err(e) => Some(Err(anyhow!("SSE transport error: {e}"))),
-            }
-        });
-
-        Ok(stream)
+    /// `tasks/resubscribe` - re-attach to an existing task by `tasks/{task_id}`
+    /// resource name and stream subsequent state transitions over SSE.
+    ///
+    /// The first event carries a snapshot of the task as currently
+    /// persisted; later events are `TaskStatusUpdateEvent` deltas as the
+    /// task progresses. The stream terminates after the server emits an
+    /// event with `final: true` (i.e. the task has reached a terminal
+    /// state).
+    pub async fn resubscribe_task(
+        &self,
+        params: SubscribeToTaskRequest,
+    ) -> Result<impl Stream<Item = Result<StreamResponse>> + Send + 'static> {
+        self.call_streaming("tasks/resubscribe", params).await
     }
 
     /// `message/stream` - drain the SSE stream and return a single
@@ -320,9 +274,128 @@ impl A2AClient {
             .await
     }
 
+    /// `agent/getAuthenticatedExtendedCard` - fetch the authenticated
+    /// extended [`AgentCard`] for the calling tenant. The server returns
+    /// the configured agent card when the card advertises
+    /// `supportsExtendedAgentCard: true`; otherwise the call surfaces a
+    /// JSON-RPC `METHOD_NOT_FOUND` error.
+    pub async fn get_authenticated_extended_card(
+        &self,
+        params: GetExtendedAgentCardRequest,
+    ) -> Result<AgentCard> {
+        self.call_typed("agent/getAuthenticatedExtendedCard", params)
+            .await
+    }
+
     // -------------------------------------------------------------------
     // Internals
     // -------------------------------------------------------------------
+
+    /// Drive a JSON-RPC method that responds over SSE, decoding each
+    /// event's `result` field as a [`StreamResponse`]. Shared by
+    /// [`A2AClient::stream_message`] and [`A2AClient::resubscribe_task`].
+    async fn call_streaming<P>(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<impl Stream<Item = Result<StreamResponse>> + Send + 'static>
+    where
+        P: Serialize,
+    {
+        let params_value = serde_json::to_value(params)
+            .map_err(|e| anyhow!("failed to serialize params for {method}: {e}"))?;
+
+        let envelope = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": Uuid::new_v4().to_string(),
+            "method": method,
+            "params": params_value,
+        });
+
+        let url = format!("{}/a2a", self.base_url);
+        let response = self
+            .http_client
+            .post(&url)
+            .header("Accept", "text/event-stream")
+            .json(&envelope)
+            .send()
+            .await
+            .map_err(|e| anyhow!("{method} request failed: {e}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!("{method} failed: HTTP {status}: {body}"));
+        }
+
+        // If the server responded with a JSON-RPC error envelope (which it
+        // does for validation / not-found errors that happen before the SSE
+        // stream begins), the content type will be JSON rather than
+        // `text/event-stream`. Inspect the content type and unwrap the
+        // error eagerly so callers don't have to fish it out of the SSE
+        // stream.
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        if !content_type.starts_with("text/event-stream") {
+            let body = response.text().await.unwrap_or_default();
+            let parsed: Value = serde_json::from_str(&body)
+                .map_err(|e| anyhow!("{method} unexpected non-SSE response: {e}: {body}"))?;
+            if let Some(err) = parsed.get("error") {
+                return Err(anyhow!("JSON-RPC error for {method}: {err}"));
+            }
+            return Err(anyhow!(
+                "{method} returned an unexpected payload (content-type={content_type:?}): {body}"
+            ));
+        }
+
+        let event_stream = response.bytes_stream().eventsource();
+        let method_owned = method.to_string();
+
+        let stream = event_stream.filter_map(move |event| {
+            let method = method_owned.clone();
+            async move {
+                match event {
+                    Ok(event) => {
+                        if event.data.is_empty() {
+                            return None;
+                        }
+                        let parsed: Value = match serde_json::from_str(&event.data) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                return Some(Err(anyhow!(
+                                    "failed to parse SSE event as JSON: {e}: {data}",
+                                    data = event.data
+                                )));
+                            }
+                        };
+                        if let Some(err) = parsed.get("error") {
+                            return Some(Err(anyhow!("JSON-RPC error in {method} stream: {err}")));
+                        }
+                        let result = match parsed.get("result").cloned() {
+                            Some(v) => v,
+                            None => {
+                                return Some(Err(anyhow!(
+                                    "SSE event missing `result`: {data}",
+                                    data = event.data
+                                )));
+                            }
+                        };
+                        match serde_json::from_value::<StreamResponse>(result) {
+                            Ok(r) => Some(Ok(r)),
+                            Err(e) => Some(Err(anyhow!("failed to decode StreamResponse: {e}"))),
+                        }
+                    }
+                    Err(e) => Some(Err(anyhow!("SSE transport error: {e}"))),
+                }
+            }
+        });
+
+        Ok(stream)
+    }
 
     async fn post_raw(&self, body: Value) -> Result<Value> {
         let url = format!("{}/a2a", self.base_url);

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -5,11 +5,11 @@ use super::server_core::A2AServer;
 use super::storage::{TaskFilter, parse_task_name};
 use super::task_handler::StreamEmitter;
 use crate::a2a_types::{
-    CancelTaskRequest, DeleteTaskPushNotificationConfigRequest,
+    CancelTaskRequest, DeleteTaskPushNotificationConfigRequest, GetExtendedAgentCardRequest,
     GetTaskPushNotificationConfigRequest, GetTaskRequest, ListTaskPushNotificationConfigRequest,
     ListTaskPushNotificationConfigResponse, ListTasksRequest, ListTasksResponse,
     SendMessageRequest, SendMessageResponse, SetTaskPushNotificationConfigRequest, StreamResponse,
-    Task, TaskState, TaskStatus, Timestamp,
+    SubscribeToTaskRequest, Task, TaskState, TaskStatus, TaskStatusUpdateEvent, Timestamp,
 };
 use axum::{
     extract::State,
@@ -89,6 +89,12 @@ pub(crate) async fn a2a_handler(
         "tasks/pushNotificationConfig/delete" => handle_delete_push_config(&state, id, params)
             .await
             .into_response(),
+        "tasks/resubscribe" => handle_tasks_resubscribe(state.clone(), id, params).await,
+        "agent/getAuthenticatedExtendedCard" => {
+            handle_get_authenticated_extended_card(&state, id, params)
+                .await
+                .into_response()
+        }
         other => {
             warn!("Unknown JSON-RPC method requested: {other}");
             json_rpc_error(
@@ -577,6 +583,224 @@ async fn handle_delete_push_config(state: &Arc<AppState>, id: Value, params: Val
     json_rpc_success(id, serde_json::json!({}))
 }
 
+/// `tasks/resubscribe` - re-attach to an existing task by `tasks/{task_id}`
+/// resource name, emit the current task state, and replay subsequent
+/// state transitions as SSE events. The stream terminates with a final
+/// `TaskStatusUpdateEvent` carrying `final: true` once the task reaches
+/// a terminal state (or the task is removed from storage).
+///
+/// The in-memory storage does not expose a pub/sub primitive, so the
+/// implementation polls the storage at a short interval and emits a
+/// status update whenever the observed `state` changes. Custom
+/// `Storage` backends can rely on the same behaviour because the
+/// `Storage` trait does not require change-stream support.
+async fn handle_tasks_resubscribe(state: Arc<AppState>, id: Value, params: Value) -> Response {
+    let request: SubscribeToTaskRequest = match serde_json::from_value(params) {
+        Ok(r) => r,
+        Err(e) => return invalid_params(id, e).into_response(),
+    };
+
+    let task_id = match parse_task_name(&request.name) {
+        Some(parsed) => parsed.to_string(),
+        None => {
+            return json_rpc_error(
+                id,
+                jsonrpc_errors::INVALID_PARAMS,
+                "Invalid params",
+                Some(Value::String(format!(
+                    "`name` must be of the form tasks/{{task_id}} (got {:?})",
+                    request.name
+                ))),
+            )
+            .into_response();
+        }
+    };
+
+    let task = match state.server.storage.get_task(&task_id).await {
+        Some(t) => t,
+        None => {
+            return json_rpc_error(
+                id,
+                jsonrpc_errors::TASK_NOT_FOUND,
+                "Task not found",
+                Some(Value::String(request.name)),
+            )
+            .into_response();
+        }
+    };
+
+    let (tx, rx) = mpsc::channel::<StreamResponse>(32);
+
+    // First event - the current task snapshot (mirrors `message/stream`).
+    let initial = StreamResponse {
+        artifact_update: None,
+        message: None,
+        status_update: None,
+        task: Some(task.clone()),
+    };
+    if tx.send(initial).await.is_err() {
+        return json_rpc_error(
+            id,
+            jsonrpc_errors::INTERNAL_ERROR,
+            "Internal error",
+            Some(Value::String(
+                "stream receiver closed before initial event".to_string(),
+            )),
+        )
+        .into_response();
+    }
+
+    let storage = Arc::clone(&state.server.storage);
+    let context_id = task.context_id.clone();
+    let initial_state = task.status.state;
+    let initial_status = task.status.clone();
+    let task_id_for_poll = task_id.clone();
+
+    tokio::spawn(async move {
+        if is_terminal_state(initial_state) {
+            let final_event = TaskStatusUpdateEvent {
+                context_id: context_id.clone(),
+                final_: true,
+                metadata: None,
+                status: initial_status,
+                task_id: task_id_for_poll,
+            };
+            let _ = tx
+                .send(StreamResponse {
+                    artifact_update: None,
+                    message: None,
+                    status_update: Some(final_event),
+                    task: None,
+                })
+                .await;
+            return;
+        }
+
+        let mut last_state = initial_state;
+        loop {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            if tx.is_closed() {
+                break;
+            }
+            let Some(updated) = storage.get_task(&task_id_for_poll).await else {
+                debug!(
+                    "resubscribe: task {task_id_for_poll} disappeared from storage; closing stream"
+                );
+                break;
+            };
+            let current_state = updated.status.state;
+            if current_state == last_state {
+                continue;
+            }
+            let is_final = is_terminal_state(current_state);
+            let event = TaskStatusUpdateEvent {
+                context_id: updated.context_id.clone(),
+                final_: is_final,
+                metadata: None,
+                status: updated.status.clone(),
+                task_id: task_id_for_poll.clone(),
+            };
+            if tx
+                .send(StreamResponse {
+                    artifact_update: None,
+                    message: None,
+                    status_update: Some(event),
+                    task: None,
+                })
+                .await
+                .is_err()
+            {
+                break;
+            }
+            last_state = current_state;
+            if is_final {
+                break;
+            }
+        }
+    });
+
+    let envelope_id = id.clone();
+    let stream = ReceiverStream::new(rx).map(move |response| {
+        let envelope = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": envelope_id.clone(),
+            "result": response,
+        });
+        Ok::<_, Infallible>(
+            Event::default()
+                .json_data(envelope)
+                .unwrap_or_else(|e| Event::default().data(format!("serialization error: {e}"))),
+        )
+    });
+
+    let stream: Box<dyn Stream<Item = Result<Event, Infallible>> + Send + Unpin> =
+        Box::new(Box::pin(stream));
+
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+/// `agent/getAuthenticatedExtendedCard` - return the authenticated extended
+/// [`AgentCard`] for the calling tenant. The server returns the configured
+/// agent card when the card advertises `supportsExtendedAgentCard: true`;
+/// otherwise it responds with `METHOD_NOT_FOUND` so callers can fall back
+/// to the unauthenticated `.well-known/agent.json` card.
+async fn handle_get_authenticated_extended_card(
+    state: &Arc<AppState>,
+    id: Value,
+    params: Value,
+) -> Json<Value> {
+    let _request: GetExtendedAgentCardRequest = match serde_json::from_value(params) {
+        Ok(r) => r,
+        Err(e) => return invalid_params(id, e),
+    };
+
+    let Some(agent_card) = state.server.agent_card.as_ref() else {
+        return json_rpc_error(
+            id,
+            jsonrpc_errors::INTERNAL_ERROR,
+            "Internal error",
+            Some(Value::String(
+                "no agent card configured on this server".to_string(),
+            )),
+        );
+    };
+
+    if !agent_card.supports_extended_agent_card.unwrap_or(false) {
+        return json_rpc_error(
+            id,
+            jsonrpc_errors::METHOD_NOT_FOUND,
+            "Method not found",
+            Some(Value::String(
+                "agent/getAuthenticatedExtendedCard is not supported by this agent \
+                 (set supportsExtendedAgentCard=true on the agent card to enable it)"
+                    .to_string(),
+            )),
+        );
+    }
+
+    match serde_json::to_value(agent_card) {
+        Ok(v) => json_rpc_success(id, v),
+        Err(e) => json_rpc_error(
+            id,
+            jsonrpc_errors::INTERNAL_ERROR,
+            "Internal error",
+            Some(Value::String(e.to_string())),
+        ),
+    }
+}
+
+fn is_terminal_state(state: TaskState) -> bool {
+    matches!(
+        state,
+        TaskState::TaskStateCompleted
+            | TaskState::TaskStateFailed
+            | TaskState::TaskStateCancelled
+            | TaskState::TaskStateRejected
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -855,5 +1079,323 @@ mod tests {
         let final_update = events[1].status_update.as_ref().expect("status update");
         assert_eq!(final_update.status.state, TaskState::TaskStateFailed);
         assert!(final_update.final_);
+    }
+
+    // ----- tasks/resubscribe -------------------------------------------
+
+    fn minimal_agent_card_for_resubscribe() -> AgentCard {
+        serde_json::from_value(serde_json::json!({
+            "name": "Resubscribe Test Agent",
+            "description": "tasks/resubscribe E2E test",
+            "version": "0.0.0",
+            "protocolVersion": "0.2.6",
+            "url": "http://localhost/a2a",
+            "preferredTransport": "JSONRPC",
+            "capabilities": {
+                "streaming": true,
+                "pushNotifications": false,
+                "stateTransitionHistory": false
+            },
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [
+                {"id": "x", "name": "x", "description": "x", "tags": ["x"]}
+            ]
+        }))
+        .expect("agent card builds")
+    }
+
+    async fn spawn_test_server(server: super::A2AServer) -> std::net::SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let app = Router::new()
+            .route("/a2a", post(a2a_handler))
+            .with_state(Arc::new(AppState { server }));
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        addr
+    }
+
+    /// Resubscribing to a task that is already in a terminal state should
+    /// emit the snapshot followed by a single final status update.
+    #[tokio::test]
+    async fn resubscribe_replays_terminal_task() {
+        use crate::A2AClient;
+        use crate::a2a_types::SubscribeToTaskRequest;
+        use futures_util::StreamExt;
+
+        let server = A2AServerBuilder::new()
+            .with_agent_card(minimal_agent_card_for_resubscribe())
+            .with_default_streaming_task_handler()
+            .build()
+            .await
+            .expect("server builds");
+
+        let storage = server.storage();
+        let task_id = uuid::Uuid::new_v4().to_string();
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let terminal_task = Task {
+            artifacts: vec![],
+            context_id: context_id.clone(),
+            history: vec![],
+            id: task_id.clone(),
+            metadata: None,
+            status: TaskStatus {
+                message: None,
+                state: TaskState::TaskStateCompleted,
+                timestamp: Some(Timestamp(chrono::Utc::now())),
+            },
+        };
+        storage
+            .create_active_task(&terminal_task)
+            .await
+            .expect("create active");
+        storage
+            .store_dead_letter_task(&terminal_task)
+            .await
+            .expect("dead-letter");
+
+        let addr = spawn_test_server(server).await;
+        let client = A2AClient::new(format!("http://{addr}")).expect("client");
+
+        let mut stream = Box::pin(
+            client
+                .resubscribe_task(SubscribeToTaskRequest {
+                    name: format!("tasks/{task_id}"),
+                    tenant: "tests".to_string(),
+                })
+                .await
+                .expect("resubscribe"),
+        );
+
+        let mut events: Vec<StreamResponse> = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.expect("event"));
+        }
+
+        assert_eq!(
+            events.len(),
+            2,
+            "expected snapshot + final event, got {events:?}"
+        );
+        let snapshot = events[0].task.as_ref().expect("first event is the task");
+        assert_eq!(snapshot.id, task_id);
+        assert_eq!(snapshot.status.state, TaskState::TaskStateCompleted);
+
+        let final_update = events[1]
+            .status_update
+            .as_ref()
+            .expect("second event is a status update");
+        assert!(final_update.final_, "terminal replay must set final=true");
+        assert_eq!(final_update.status.state, TaskState::TaskStateCompleted);
+        assert_eq!(final_update.task_id, task_id);
+    }
+
+    /// Resubscribing to a live task should emit the snapshot, then a
+    /// status update per observed state change, terminating with
+    /// `final: true` once the task reaches a terminal state.
+    #[tokio::test]
+    async fn resubscribe_replays_live_state_transitions() {
+        use crate::A2AClient;
+        use crate::a2a_types::SubscribeToTaskRequest;
+        use futures_util::StreamExt;
+
+        let server = A2AServerBuilder::new()
+            .with_agent_card(minimal_agent_card_for_resubscribe())
+            .with_default_streaming_task_handler()
+            .build()
+            .await
+            .expect("server builds");
+
+        let storage = server.storage();
+        let task_id = uuid::Uuid::new_v4().to_string();
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let initial_task = Task {
+            artifacts: vec![],
+            context_id: context_id.clone(),
+            history: vec![],
+            id: task_id.clone(),
+            metadata: None,
+            status: TaskStatus {
+                message: None,
+                state: TaskState::TaskStateWorking,
+                timestamp: Some(Timestamp(chrono::Utc::now())),
+            },
+        };
+        storage
+            .create_active_task(&initial_task)
+            .await
+            .expect("create active");
+
+        let storage_for_driver = Arc::clone(&storage);
+        let task_id_for_driver = task_id.clone();
+        let context_id_for_driver = context_id.clone();
+        tokio::spawn(async move {
+            // Give the resubscribe handler time to send the snapshot and
+            // start polling before we move the task to a terminal state.
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            let completed = Task {
+                artifacts: vec![],
+                context_id: context_id_for_driver,
+                history: vec![],
+                id: task_id_for_driver,
+                metadata: None,
+                status: TaskStatus {
+                    message: None,
+                    state: TaskState::TaskStateCompleted,
+                    timestamp: Some(Timestamp(chrono::Utc::now())),
+                },
+            };
+            storage_for_driver.put_task(completed).await;
+        });
+
+        let addr = spawn_test_server(server).await;
+        let client = A2AClient::new(format!("http://{addr}")).expect("client");
+
+        let mut stream = Box::pin(
+            client
+                .resubscribe_task(SubscribeToTaskRequest {
+                    name: format!("tasks/{task_id}"),
+                    tenant: "tests".to_string(),
+                })
+                .await
+                .expect("resubscribe"),
+        );
+
+        let mut events: Vec<StreamResponse> = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.expect("event"));
+        }
+
+        assert!(
+            events.len() >= 2,
+            "expected snapshot + at least one status update, got {events:?}"
+        );
+        let snapshot = events[0].task.as_ref().expect("first event is the task");
+        assert_eq!(snapshot.id, task_id);
+        assert_eq!(snapshot.status.state, TaskState::TaskStateWorking);
+
+        let last = events.last().expect("at least one event");
+        let final_update = last
+            .status_update
+            .as_ref()
+            .expect("last event is a status update");
+        assert!(final_update.final_, "stream must terminate with final=true");
+        assert_eq!(final_update.status.state, TaskState::TaskStateCompleted);
+    }
+
+    /// `tasks/resubscribe` against a missing task should surface a
+    /// JSON-RPC `TASK_NOT_FOUND` error rather than opening an empty
+    /// stream that never closes.
+    #[tokio::test]
+    async fn resubscribe_returns_task_not_found_for_unknown_task() {
+        use crate::A2AClient;
+        use crate::a2a_types::SubscribeToTaskRequest;
+
+        let server = A2AServerBuilder::new()
+            .with_agent_card(minimal_agent_card_for_resubscribe())
+            .with_default_streaming_task_handler()
+            .build()
+            .await
+            .expect("server builds");
+
+        let addr = spawn_test_server(server).await;
+        let client = A2AClient::new(format!("http://{addr}")).expect("client");
+
+        let result = client
+            .resubscribe_task(SubscribeToTaskRequest {
+                name: "tasks/does-not-exist".to_string(),
+                tenant: "tests".to_string(),
+            })
+            .await;
+        let err = result
+            .err()
+            .expect("resubscribe against missing task must error");
+        let message = err.to_string();
+        assert!(
+            message.contains("Task not found") || message.contains("-32001"),
+            "expected TASK_NOT_FOUND error, got: {message}"
+        );
+    }
+
+    // ----- agent/getAuthenticatedExtendedCard --------------------------
+
+    fn agent_card_with_extended(supports: bool) -> AgentCard {
+        serde_json::from_value(serde_json::json!({
+            "name": "Extended Card Agent",
+            "description": "agent/getAuthenticatedExtendedCard test",
+            "version": "1.2.3",
+            "protocolVersion": "0.2.6",
+            "url": "http://localhost/a2a",
+            "preferredTransport": "JSONRPC",
+            "capabilities": {
+                "streaming": true,
+                "pushNotifications": false,
+                "stateTransitionHistory": false
+            },
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [
+                {"id": "x", "name": "x", "description": "x", "tags": ["x"]}
+            ],
+            "supportsExtendedAgentCard": supports
+        }))
+        .expect("agent card builds")
+    }
+
+    #[tokio::test]
+    async fn get_authenticated_extended_card_returns_card_when_supported() {
+        use crate::A2AClient;
+        use crate::a2a_types::GetExtendedAgentCardRequest;
+
+        let server = A2AServerBuilder::new()
+            .with_agent_card(agent_card_with_extended(true))
+            .with_default_streaming_task_handler()
+            .build()
+            .await
+            .expect("server builds");
+
+        let addr = spawn_test_server(server).await;
+        let client = A2AClient::new(format!("http://{addr}")).expect("client");
+
+        let card = client
+            .get_authenticated_extended_card(GetExtendedAgentCardRequest {
+                tenant: "tests".to_string(),
+            })
+            .await
+            .expect("extended card");
+
+        assert_eq!(card.name, "Extended Card Agent");
+        assert_eq!(card.version, "1.2.3");
+        assert_eq!(card.supports_extended_agent_card, Some(true));
+    }
+
+    #[tokio::test]
+    async fn get_authenticated_extended_card_rejects_when_not_supported() {
+        use crate::A2AClient;
+        use crate::a2a_types::GetExtendedAgentCardRequest;
+
+        let server = A2AServerBuilder::new()
+            .with_agent_card(agent_card_with_extended(false))
+            .with_default_streaming_task_handler()
+            .build()
+            .await
+            .expect("server builds");
+
+        let addr = spawn_test_server(server).await;
+        let client = A2AClient::new(format!("http://{addr}")).expect("client");
+
+        let err = client
+            .get_authenticated_extended_card(GetExtendedAgentCardRequest {
+                tenant: "tests".to_string(),
+            })
+            .await
+            .expect_err("expected METHOD_NOT_FOUND when extended card disabled");
+        let message = err.to_string();
+        assert!(
+            message.contains("Method not found") || message.contains("-32601"),
+            "expected METHOD_NOT_FOUND, got: {message}"
+        );
     }
 }

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -1231,8 +1231,6 @@ mod tests {
         let task_id_for_driver = task_id.clone();
         let context_id_for_driver = context_id.clone();
         tokio::spawn(async move {
-            // Give the resubscribe handler time to send the snapshot and
-            // start polling before we move the task to a terminal state.
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
             let completed = Task {
                 artifacts: vec![],

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -631,7 +631,6 @@ async fn handle_tasks_resubscribe(state: Arc<AppState>, id: Value, params: Value
 
     let (tx, rx) = mpsc::channel::<StreamResponse>(32);
 
-    // First event - the current task snapshot (mirrors `message/stream`).
     let initial = StreamResponse {
         artifact_update: None,
         message: None,

--- a/tests/a2a_server_test.rs
+++ b/tests/a2a_server_test.rs
@@ -617,3 +617,83 @@ async fn client_typed_helpers_round_trip_send_and_list() {
         .expect("list_tasks ok");
     assert!(listed.total_size >= 1);
 }
+
+#[tokio::test]
+async fn tasks_resubscribe_returns_snapshot_and_final_event() {
+    use futures::StreamExt;
+
+    let suite = ensure_suite();
+    let task = create_task(suite, "resubscribe round-trip").await;
+
+    let client = A2AClient::new(&suite.base_url).expect("client builds");
+    let mut stream = Box::pin(
+        client
+            .resubscribe_task(a2a_types::SubscribeToTaskRequest {
+                name: format!("tasks/{}", task.id),
+                tenant: "test".to_string(),
+            })
+            .await
+            .expect("resubscribe_task ok"),
+    );
+
+    // The first event must carry the task snapshot.
+    let first = timeout(suite.timeout_duration, stream.next())
+        .await
+        .expect("first event arrives")
+        .expect("stream not empty")
+        .expect("first event decodes");
+    let snapshot = first.task.expect("first event carries task snapshot");
+    assert_eq!(snapshot.id, task.id);
+
+    // Background handler is `SubmittedTaskHandler`, so the task stays in
+    // `Submitted` indefinitely; just drop the stream after reading the
+    // snapshot - that closes the SSE response channel cleanly.
+    drop(stream);
+}
+
+#[tokio::test]
+async fn tasks_resubscribe_unknown_task_returns_task_not_found() {
+    let suite = ensure_suite();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "test-resubscribe-not-found",
+        "method": "tasks/resubscribe",
+        "params": {
+            "name": "tasks/does-not-exist",
+            "tenant": "test"
+        }
+    });
+    let response = post_jsonrpc(suite, request).await;
+    let code = response
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(|c| c.as_i64());
+    assert_eq!(
+        code,
+        Some(-32001),
+        "expected TASK_NOT_FOUND, got {response}"
+    );
+}
+
+#[tokio::test]
+async fn get_authenticated_extended_card_rejects_when_not_supported() {
+    // The shared test agent card does not opt in to extended card
+    // retrieval, so the server should respond with METHOD_NOT_FOUND.
+    let suite = ensure_suite();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "test-get-extended-card-disabled",
+        "method": "agent/getAuthenticatedExtendedCard",
+        "params": { "tenant": "test" }
+    });
+    let response = post_jsonrpc(suite, request).await;
+    let code = response
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(|c| c.as_i64());
+    assert_eq!(
+        code,
+        Some(-32601),
+        "expected METHOD_NOT_FOUND, got {response}"
+    );
+}

--- a/tests/a2a_server_test.rs
+++ b/tests/a2a_server_test.rs
@@ -636,7 +636,6 @@ async fn tasks_resubscribe_returns_snapshot_and_final_event() {
             .expect("resubscribe_task ok"),
     );
 
-    // The first event must carry the task snapshot.
     let first = timeout(suite.timeout_duration, stream.next())
         .await
         .expect("first event arrives")
@@ -645,9 +644,6 @@ async fn tasks_resubscribe_returns_snapshot_and_final_event() {
     let snapshot = first.task.expect("first event carries task snapshot");
     assert_eq!(snapshot.id, task.id);
 
-    // Background handler is `SubmittedTaskHandler`, so the task stays in
-    // `Submitted` indefinitely; just drop the stream after reading the
-    // snapshot - that closes the SSE response channel cleanly.
     drop(stream);
 }
 
@@ -677,8 +673,6 @@ async fn tasks_resubscribe_unknown_task_returns_task_not_found() {
 
 #[tokio::test]
 async fn get_authenticated_extended_card_rejects_when_not_supported() {
-    // The shared test agent card does not opt in to extended card
-    // retrieval, so the server should respond with METHOD_NOT_FOUND.
     let suite = ensure_suite();
     let request = json!({
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Implements the two A2A JSON-RPC methods declared in the canonical schema but missing from the Rust ADK:

- `tasks/resubscribe` — re-attach to an existing task and replay subsequent state transitions over SSE.
- `agent/getAuthenticatedExtendedCard` — return the authenticated extended `AgentCard` when the agent advertises `supportsExtendedAgentCard: true`; otherwise `METHOD_NOT_FOUND`.

Adds typed `A2AClient` helpers (`resubscribe_task`, `get_authenticated_extended_card`), updates the README method table and snippets, and adds unit + integration coverage.

Storage trait is unchanged: resubscribe polls at 100 ms intervals so any `Storage` backend (in-memory, Redis, custom) works unmodified.

Closes #22

## Test plan

- [x] `task lint`
- [x] `task analyse` (clippy `-D warnings`)
- [x] `task test` — 43 lib tests + 17 integration tests, 0 failures
- [x] New unit tests cover: terminal replay, live state transitions, unknown-task error, extended-card success + `METHOD_NOT_FOUND`
- [x] New integration tests cover: resubscribe snapshot, `TASK_NOT_FOUND` over JSON-RPC, extended-card `METHOD_NOT_FOUND` on a non-opted-in card

Generated with [Claude Code](https://claude.ai/code)