### PR TITLE
docs(examples): Add tasks/resubscribe and agent/getAuthenticatedExtendedCard examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,14 @@ name = "a2a-methods-push-config-delete"
 path = "examples/a2a-methods/client/push_config_delete.rs"
 
 [[example]]
+name = "a2a-methods-tasks-resubscribe"
+path = "examples/a2a-methods/client/tasks_resubscribe.rs"
+
+[[example]]
+name = "a2a-methods-agent-authenticated-extended-card"
+path = "examples/a2a-methods/client/agent_authenticated_extended_card.rs"
+
+[[example]]
 name = "queue-storage-server"
 path = "examples/queue-storage/server/main.rs"
 

--- a/examples/a2a-methods/README.md
+++ b/examples/a2a-methods/README.md
@@ -9,40 +9,44 @@ JSON envelopes.
 
 ```text
 a2a-methods/
-├── docker-compose.yaml                  # Server + one Compose profile per client
-├── server/main.rs                       # shared offline server (echo fallback)
+├── docker-compose.yaml                          # Server + one Compose profile per client
+├── server/main.rs                               # shared offline server (echo fallback)
 └── client/
-    ├── message_send.rs                  # message/send
-    ├── message_stream.rs                # message/stream
-    ├── tasks_get.rs                     # tasks/get
-    ├── tasks_list.rs                    # tasks/list
-    ├── tasks_cancel.rs                  # tasks/cancel
-    ├── push_config_set.rs               # tasks/pushNotificationConfig/set
-    ├── push_config_get.rs               # tasks/pushNotificationConfig/get
-    ├── push_config_list.rs              # tasks/pushNotificationConfig/list
-    └── push_config_delete.rs            # tasks/pushNotificationConfig/delete
+    ├── message_send.rs                          # message/send
+    ├── message_stream.rs                        # message/stream
+    ├── tasks_get.rs                             # tasks/get
+    ├── tasks_list.rs                            # tasks/list
+    ├── tasks_cancel.rs                          # tasks/cancel
+    ├── tasks_resubscribe.rs                     # tasks/resubscribe
+    ├── push_config_set.rs                       # tasks/pushNotificationConfig/set
+    ├── push_config_get.rs                       # tasks/pushNotificationConfig/get
+    ├── push_config_list.rs                      # tasks/pushNotificationConfig/list
+    ├── push_config_delete.rs                    # tasks/pushNotificationConfig/delete
+    └── agent_authenticated_extended_card.rs     # agent/getAuthenticatedExtendedCard
 ```
 
 ## Running with Docker Compose
 
-The compose manifest builds one long-running `server` container plus nine
+The compose manifest builds one long-running `server` container plus eleven
 per-method client containers, each parked behind its own
 [Compose profile][compose-profiles] so a bare `docker compose up` doesn't
-fan out into nine parallel runs.
+fan out into eleven parallel runs.
 
 ```bash
 cd examples/a2a-methods
 
 # Pick a single method to exercise:
-docker compose --profile message-send       up --build
-docker compose --profile message-stream     up --build
-docker compose --profile tasks-get          up --build
-docker compose --profile tasks-list         up --build
-docker compose --profile tasks-cancel       up --build
-docker compose --profile push-config-set    up --build
-docker compose --profile push-config-get    up --build
-docker compose --profile push-config-list   up --build
-docker compose --profile push-config-delete up --build
+docker compose --profile message-send                       up --build
+docker compose --profile message-stream                     up --build
+docker compose --profile tasks-get                          up --build
+docker compose --profile tasks-list                         up --build
+docker compose --profile tasks-cancel                       up --build
+docker compose --profile tasks-resubscribe                  up --build
+docker compose --profile push-config-set                    up --build
+docker compose --profile push-config-get                    up --build
+docker compose --profile push-config-list                   up --build
+docker compose --profile push-config-delete                 up --build
+docker compose --profile agent-authenticated-extended-card  up --build
 
 # Or run every client in sequence against the same server:
 docker compose --profile all-clients up --build
@@ -70,10 +74,12 @@ cargo run --example a2a-methods-message-stream
 cargo run --example a2a-methods-tasks-get
 cargo run --example a2a-methods-tasks-list
 cargo run --example a2a-methods-tasks-cancel
+cargo run --example a2a-methods-tasks-resubscribe
 cargo run --example a2a-methods-push-config-set
 cargo run --example a2a-methods-push-config-get
 cargo run --example a2a-methods-push-config-list
 cargo run --example a2a-methods-push-config-delete
+cargo run --example a2a-methods-agent-authenticated-extended-card
 ```
 
 The server listens on port `8085` by default (override with `SERVER_PORT=…`).
@@ -90,3 +96,14 @@ Clients respect `SERVER_URL` and default to `http://localhost:8085`.
 - Webhook *delivery* for push notifications is tracked in a separate ticket;
   the four `pushNotificationConfig/*` methods here exercise the control plane
   (storage + retrieval) only.
+- The shared example server opts into the extended agent card by setting
+  `supportsExtendedAgentCard: true` on the static agent card it advertises;
+  this is what lets `a2a-methods-agent-authenticated-extended-card` succeed
+  rather than receive `METHOD_NOT_FOUND`. Production agents should gate the
+  flag on their own auth policy.
+- `tasks/resubscribe` lets a client re-attach to an existing
+  `tasks/{task_id}` resource and receive a snapshot of its current state
+  followed by any remaining `TaskStatusUpdateEvent` deltas. The example
+  here seeds a task via `message/send` (which the echo handler completes
+  immediately) so the resubscribed stream emits a snapshot and a terminal
+  `final: true` update.

--- a/examples/a2a-methods/client/agent_authenticated_extended_card.rs
+++ b/examples/a2a-methods/client/agent_authenticated_extended_card.rs
@@ -1,0 +1,66 @@
+//! `agent/getAuthenticatedExtendedCard` - fetch the authenticated extended
+//! [`AgentCard`] for the calling tenant.
+//!
+//! The example server advertises `supportsExtendedAgentCard: true` on its
+//! agent card, so the JSON-RPC call returns the configured card. When the
+//! flag is absent or `false`, the server responds with
+//! `METHOD_NOT_FOUND` so clients can fall back to the unauthenticated
+//! card served at `/.well-known/agent.json`.
+//!
+//! For contrast, the example also fetches the unauthenticated card from
+//! the discovery endpoint and logs both side-by-side.
+//!
+//! ```bash
+//! cargo run --example a2a-methods-server
+//! cargo run --example a2a-methods-agent-authenticated-extended-card
+//! ```
+use inference_gateway_adk::A2AClient;
+use inference_gateway_adk::a2a_types::GetExtendedAgentCardRequest;
+use std::env;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt().init();
+
+    let server_url = env::var("SERVER_URL").unwrap_or_else(|_| "http://localhost:8085".to_string());
+    let client = A2AClient::new(&server_url)?;
+
+    // 1. Unauthenticated card (discovery endpoint) for comparison.
+    let discovery_card = client.get_agent_card().await?;
+    info!(
+        "/.well-known/agent.json → name={:?} version={:?} supportsExtendedAgentCard={:?}",
+        discovery_card.name, discovery_card.version, discovery_card.supports_extended_agent_card
+    );
+
+    // 2. Authenticated extended card via JSON-RPC.
+    match client
+        .get_authenticated_extended_card(GetExtendedAgentCardRequest {
+            tenant: "example".to_string(),
+        })
+        .await
+    {
+        Ok(extended_card) => {
+            info!(
+                "agent/getAuthenticatedExtendedCard → name={:?} version={:?} skills={} description={:?}",
+                extended_card.name,
+                extended_card.version,
+                extended_card.skills.len(),
+                extended_card.description,
+            );
+        }
+        Err(err) => {
+            // The server returns METHOD_NOT_FOUND when the underlying
+            // agent card does not advertise supportsExtendedAgentCard=true.
+            // Clients should fall back to the discovery card in that
+            // case - the example server opts in, so this branch should
+            // not fire when running against `a2a-methods-server`.
+            info!(
+                "agent/getAuthenticatedExtendedCard not available ({err}); \
+                 falling back to the unauthenticated card from /.well-known/agent.json"
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/examples/a2a-methods/client/tasks_resubscribe.rs
+++ b/examples/a2a-methods/client/tasks_resubscribe.rs
@@ -1,0 +1,113 @@
+//! `tasks/resubscribe` - re-attach to an existing task and stream its
+//! remaining state transitions over SSE.
+//!
+//! The example seeds a task via `message/send` (the offline echo handler
+//! drives it straight to `Completed`), then calls `tasks/resubscribe` to
+//! demonstrate the recovery path: the server replays a snapshot of the
+//! task's current state followed by a `TaskStatusUpdateEvent` with
+//! `final: true`, and the stream closes cleanly.
+//!
+//! This mirrors the canonical use of `tasks/resubscribe` after a transport
+//! disconnect - the client knows the `tasks/{task_id}` resource name and
+//! wants to resume observing the task without re-issuing
+//! `message/stream`.
+//!
+//! ```bash
+//! cargo run --example a2a-methods-server
+//! cargo run --example a2a-methods-tasks-resubscribe
+//! ```
+use futures::StreamExt;
+use inference_gateway_adk::A2AClient;
+use inference_gateway_adk::a2a_types::{
+    Message, Part, Role, SendMessageRequest, SubscribeToTaskRequest,
+};
+use std::env;
+use tracing::info;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt().init();
+
+    let server_url = env::var("SERVER_URL").unwrap_or_else(|_| "http://localhost:8085".to_string());
+    let client = A2AClient::new(&server_url)?;
+
+    // 1. Seed a task we can later resubscribe to. The example server's
+    //    EchoBackgroundTaskHandler drives the task through to `Completed`
+    //    synchronously, so the resubscribe below will see a terminal task.
+    let seed = client
+        .send_message(SendMessageRequest {
+            configuration: None,
+            message: Some(Message {
+                context_id: None,
+                extensions: vec![],
+                message_id: Uuid::new_v4().to_string(),
+                metadata: None,
+                parts: vec![Part {
+                    data: None,
+                    file: None,
+                    metadata: None,
+                    text: Some("seed for tasks/resubscribe".to_string()),
+                }],
+                reference_task_ids: vec![],
+                role: Role::RoleUser,
+                task_id: None,
+            }),
+            metadata: None,
+            tenant: "example".to_string(),
+        })
+        .await?;
+    let seeded_task = seed.task.ok_or("server did not return a task")?;
+    let task_resource = format!("tasks/{}", seeded_task.id);
+
+    info!(
+        "seeded task {} (state {:?}); resubscribing...",
+        seeded_task.id, seeded_task.status.state
+    );
+
+    // 2. Resubscribe. The server replays a snapshot of the task followed
+    //    by a final TaskStatusUpdateEvent and then closes the stream.
+    let mut stream = Box::pin(
+        client
+            .resubscribe_task(SubscribeToTaskRequest {
+                name: task_resource.clone(),
+                tenant: "example".to_string(),
+            })
+            .await?,
+    );
+
+    let mut event_index = 0usize;
+    while let Some(event) = stream.next().await {
+        let response = event?;
+        event_index += 1;
+
+        if let Some(task) = response.task {
+            info!(
+                "[{event_index}] tasks/resubscribe → snapshot: id={} state={:?}",
+                task.id, task.status.state
+            );
+        }
+
+        if let Some(update) = response.status_update {
+            let suffix = if update.final_ { " (final)" } else { "" };
+            info!(
+                "[{event_index}] tasks/resubscribe → status update: {:?}{suffix}",
+                update.status.state
+            );
+        }
+
+        if let Some(artifact_event) = response.artifact_update {
+            let text = artifact_event
+                .artifact
+                .parts
+                .iter()
+                .filter_map(|p| p.text.clone())
+                .collect::<Vec<_>>()
+                .join("");
+            info!("[{event_index}] tasks/resubscribe → artifact: {:?}", text);
+        }
+    }
+
+    info!("tasks/resubscribe → stream closed after {event_index} events");
+    Ok(())
+}

--- a/examples/a2a-methods/docker-compose.yaml
+++ b/examples/a2a-methods/docker-compose.yaml
@@ -1,21 +1,23 @@
 ---
 # Docker Compose manifest for the `a2a-methods` example collection.
 #
-# Layout: one long-running server + nine per-method clients (one Cargo example
-# per JSON-RPC method in the A2A spec). Each client is parked behind its own
-# Compose profile so `docker compose up` doesn't fan out into nine parallel
-# runs. Pick the method you want to exercise:
+# Layout: one long-running server + eleven per-method clients (one Cargo
+# example per JSON-RPC method in the A2A spec). Each client is parked behind
+# its own Compose profile so `docker compose up` doesn't fan out into eleven
+# parallel runs. Pick the method you want to exercise:
 #
 #   docker compose up --build server
-#   docker compose --profile message-send       up --build
-#   docker compose --profile message-stream     up --build
-#   docker compose --profile tasks-get          up --build
-#   docker compose --profile tasks-list         up --build
-#   docker compose --profile tasks-cancel       up --build
-#   docker compose --profile push-config-set    up --build
-#   docker compose --profile push-config-get    up --build
-#   docker compose --profile push-config-list   up --build
-#   docker compose --profile push-config-delete up --build
+#   docker compose --profile message-send                       up --build
+#   docker compose --profile message-stream                     up --build
+#   docker compose --profile tasks-get                          up --build
+#   docker compose --profile tasks-list                         up --build
+#   docker compose --profile tasks-cancel                       up --build
+#   docker compose --profile tasks-resubscribe                  up --build
+#   docker compose --profile push-config-set                    up --build
+#   docker compose --profile push-config-get                    up --build
+#   docker compose --profile push-config-list                   up --build
+#   docker compose --profile push-config-delete                 up --build
+#   docker compose --profile agent-authenticated-extended-card  up --build
 #
 # Or run every client back-to-back via the `all-clients` profile:
 #
@@ -132,6 +134,23 @@ services:
       - tasks-cancel
       - all-clients
 
+  tasks-resubscribe:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile.client
+      args:
+        BIN_NAME: a2a-methods-tasks-resubscribe
+    depends_on:
+      server:
+        condition: service_healthy
+    environment:
+      SERVER_URL: http://server:8085
+    networks:
+      - a2a-network
+    profiles:
+      - tasks-resubscribe
+      - all-clients
+
   push-config-set:
     build:
       context: ../..
@@ -198,6 +217,23 @@ services:
       - a2a-network
     profiles:
       - push-config-delete
+      - all-clients
+
+  agent-authenticated-extended-card:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile.client
+      args:
+        BIN_NAME: a2a-methods-agent-authenticated-extended-card
+    depends_on:
+      server:
+        condition: service_healthy
+    environment:
+      SERVER_URL: http://server:8085
+    networks:
+      - a2a-network
+    profiles:
+      - agent-authenticated-extended-card
       - all-clients
 
 networks:

--- a/examples/a2a-methods/server/main.rs
+++ b/examples/a2a-methods/server/main.rs
@@ -145,6 +145,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "pushNotifications": true,
             "stateTransitionHistory": false
         },
+        // Opt the example in to `agent/getAuthenticatedExtendedCard` so the
+        // dedicated client example returns a card instead of METHOD_NOT_FOUND.
+        "supportsExtendedAgentCard": true,
         "defaultInputModes": ["text/plain"],
         "defaultOutputModes": ["text/plain"],
         "skills": [


### PR DESCRIPTION
## Summary

Adds runnable client examples for the two A2A JSON-RPC methods that previously had no example coverage: `tasks/resubscribe` and `agent/getAuthenticatedExtendedCard`. The README table and per-method snippets were already in place; this PR just fills in the missing example programs.

- New `examples/a2a-methods/client/tasks_resubscribe.rs` seeds a task via `message/send` and then re-attaches via `tasks/resubscribe`, draining snapshot + terminal status events.
- New `examples/a2a-methods/client/agent_authenticated_extended_card.rs` fetches the discovery card for comparison, then calls `agent/getAuthenticatedExtendedCard` and falls back on `METHOD_NOT_FOUND`.
- Shared `examples/a2a-methods/server/main.rs` now opts the agent card into `supportsExtendedAgentCard: true`.
- `Cargo.toml`, `examples/a2a-methods/docker-compose.yaml`, and `examples/a2a-methods/README.md` register and document the new examples alongside the existing ones.

Closes #23

## Test plan

- [x] `task lint`
- [x] `task analyse`
- [x] `task test`
- [ ] Manual: `cargo run --example a2a-methods-server` + `cargo run --example a2a-methods-tasks-resubscribe`
- [ ] Manual: `cargo run --example a2a-methods-server` + `cargo run --example a2a-methods-agent-authenticated-extended-card`

Generated with [Claude Code](https://claude.ai/code)