### PR TITLE
fix(config): align enable env vars with the Go ADK's *_ENABLED naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Build A2A servers with custom configurations using a fluent interface. See
 | `with_streaming_task_handler(h)` | Custom `message/stream` handler. |
 | `with_default_task_handlers()` | Wire in the LLM-backed defaults for both. |
 | `with_workers(n)` | Number of queue workers to spawn. |
-| `with_auth_verifier(v)` | Plug in a custom `AuthVerifier` (overrides `A2A_AUTH_ENABLE`). |
+| `with_auth_verifier(v)` | Plug in a custom `AuthVerifier` (overrides `A2A_AUTH_ENABLED`). |
 
 #### AgentBuilder
 
@@ -1130,7 +1130,7 @@ for a runnable end-to-end demo.
 
 ### Authentication
 
-When `A2A_AUTH_ENABLE=true`, the server gates `POST /a2a` behind an
+When `A2A_AUTH_ENABLED=true`, the server gates `POST /a2a` behind an
 `Authorization: Bearer <token>` header validated against the OIDC issuer
 configured by `A2A_AUTH_ISSUER_URL`. The bundled `OidcJwtVerifier`:
 
@@ -1147,14 +1147,14 @@ Tokens that fail any check produce **HTTP 401** with a
 To plug in a custom backend (static keys, internal identity service,
 mocks for tests) implement `AuthVerifier` and pass it to
 `A2AServerBuilder::with_auth_verifier(...)` - this overrides whatever
-`A2A_AUTH_ENABLE` selects and works the same way `with_storage(...)` does.
+`A2A_AUTH_ENABLED` selects and works the same way `with_storage(...)` does.
 
 The authenticated principal (subject, tenant, all JWT claims) is
 attached to the request via an Axum extension and forwarded to the
 JSON-RPC dispatcher so per-tenant filtering of the extended agent card
 is a future no-op behind a feature flag rather than a breaking change.
 
-**Behaviour when `A2A_AUTH_ENABLE=false`** - the middleware is not attached
+**Behaviour when `A2A_AUTH_ENABLED=false`** - the middleware is not attached
 and `agent/getAuthenticatedExtendedCard` returns the configured card
 whenever `supportsExtendedAgentCard == true` on the agent card. This
 preserves backwards compatibility for callers who have not opted in to
@@ -1167,7 +1167,7 @@ See [`examples/auth/`](./examples/auth/) for a runnable end-to-end demo.
 
 ### TLS and mTLS
 
-When `A2A_SERVER_TLS_ENABLE=true`, `A2AServer::serve` swaps its plaintext
+When `A2A_SERVER_TLS_ENABLED=true`, `A2AServer::serve` swaps its plaintext
 Axum listener for `axum-server` backed by `rustls` (with the `ring`
 crypto provider) and serves the same Axum router over HTTPS. The
 configuration lives on `Config.tls_config` and is populated by whatever
@@ -1176,7 +1176,7 @@ bundled examples:
 
 | Variable | Purpose |
 | --- | --- |
-| `A2A_SERVER_TLS_ENABLE` | Set to `true` to flip `A2AServer::serve` onto the TLS listener. |
+| `A2A_SERVER_TLS_ENABLED` | Set to `true` to flip `A2AServer::serve` onto the TLS listener. |
 | `A2A_SERVER_TLS_CERT_PATH` | PEM file with the server certificate chain. |
 | `A2A_SERVER_TLS_KEY_PATH` | PEM file with the server private key (PKCS#1, PKCS#8, or SEC1). |
 | `A2A_SERVER_TLS_CLIENT_CA_PATH` | Optional. When set, the server requires every TLS client to present a certificate signed by one of the CAs in this PEM bundle - i.e. mutual TLS, the `MutualTlsSecurityScheme` the A2A spec describes. |
@@ -1225,12 +1225,12 @@ deployments can plug in their own backends:
 
 | Layer | Trait / type | Default |
 | --- | --- | --- |
-| Configuration | `ArtifactsConfig` in `src/config.rs` | disabled (`ARTIFACTS_ENABLE=false`) |
+| Configuration | `ArtifactsConfig` in `src/config.rs` | disabled (`ARTIFACTS_ENABLED=false`) |
 | Storage backend | `ArtifactStorage` (`store`, `retrieve`, `exists`, `delete`, `cleanup_*`) | `FilesystemArtifactStorage` |
 | Helper service | `ArtifactService` (`create_*_artifact`, `add_artifact_to_task`, retention) | `DefaultArtifactService` |
 | HTTP surface | `ArtifactsServer` (`GET /health`, `GET /artifacts/:artifact_id/:filename`) | `:8081` listener with range support |
 
-When `ARTIFACTS_ENABLE=true`, `A2AServer::serve(...)` spawns the
+When `ARTIFACTS_ENABLED=true`, `A2AServer::serve(...)` spawns the
 artifacts HTTP server on its own listener alongside the main A2A
 JSON-RPC server and runs a background retention loop that prunes
 expired / over-cap blobs. The TLS layer reuses the same
@@ -1249,7 +1249,7 @@ file directly from the artifacts server.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `ARTIFACTS_ENABLE` | `false` | Master switch — when `true`, `A2AServer::serve(...)` spawns the artifacts server and retention loop. |
+| `ARTIFACTS_ENABLED` | `false` | Master switch — when `true`, `A2AServer::serve(...)` spawns the artifacts server and retention loop. |
 | `ARTIFACTS_SERVER_HOST` | `0.0.0.0` | Bind address of the artifacts HTTP server. |
 | `ARTIFACTS_SERVER_PORT` | `8081` | Port of the artifacts HTTP server. |
 | `ARTIFACTS_SERVER_READ_TIMEOUT` | `30s` | Per-request read timeout. Accepts Go-style durations (`30s`, `5m`, `2h`, `7d`) or bare seconds. |
@@ -1395,20 +1395,20 @@ A2A_QUEUE_NAMESPACE="a2a"
 A2A_QUEUE_WORKERS="1"
 
 # Authentication (optional, OIDC bearer-token JWT)
-A2A_AUTH_ENABLE="false"                                                   # when true, POST /a2a requires a valid bearer token
+A2A_AUTH_ENABLED="false"                                                   # when true, POST /a2a requires a valid bearer token
 A2A_AUTH_ISSUER_URL="http://keycloak:8080/realms/inference-gateway-realm" # OIDC issuer; the server performs discovery + JWKS lookup
 A2A_AUTH_CLIENT_ID="inference-gateway-client"                             # validated as the JWT audience when set
 A2A_AUTH_CLIENT_SECRET="your-secret"                                      # currently unused server-side (reserved for client-side OAuth2)
 
 # TLS (optional)
-A2A_SERVER_TLS_ENABLE="false"                   # when true, A2AServer::serve binds an HTTPS listener via axum-server + rustls
+A2A_SERVER_TLS_ENABLED="false"                   # when true, A2AServer::serve binds an HTTPS listener via axum-server + rustls
 A2A_SERVER_TLS_CERT_PATH="/path/to/cert.pem"    # PEM-encoded server certificate chain
 A2A_SERVER_TLS_KEY_PATH="/path/to/key.pem"      # PEM-encoded private key (PKCS#1, PKCS#8, or SEC1)
 A2A_SERVER_TLS_CLIENT_CA_PATH=""                # optional: when set, the server requires mTLS and trusts client certs signed by the CAs in this PEM bundle
 
 # Telemetry (optional, OpenTelemetry). Standard OTEL_* env vars (e.g.
 # OTEL_EXPORTER_OTLP_ENDPOINT) are honored by the SDK as usual.
-A2A_TELEMETRY_ENABLE="false"                    # single gate for telemetry; when true, traces default to the OTLP exporter
+A2A_TELEMETRY_ENABLED="false"                    # single gate for telemetry; when true, traces default to the OTLP exporter
 A2A_TELEMETRY_ENDPOINT=""                        # OTLP collector endpoint; overrides OTEL_EXPORTER_OTLP_ENDPOINT (default http://localhost:4318)
 A2A_OTEL_TRACES_EXPORTER="otlp"                 # `otlp` (default) or `none` to opt the trace signal out while telemetry stays enabled
 ```
@@ -1433,7 +1433,7 @@ let config = envy::prefixed("A2A_").from_env::<Config>().unwrap_or_default();
 let _guard = telemetry::init(&config.telemetry_config, "my-agent", env!("CARGO_PKG_VERSION"))?;
 ```
 
-`init` always installs the `tracing` fmt layer; when `A2A_TELEMETRY_ENABLE=true`
+`init` always installs the `tracing` fmt layer; when `A2A_TELEMETRY_ENABLED=true`
 **and** the feature is compiled in, it also installs a `tracing-opentelemetry`
 layer that batches spans to an OTLP collector over HTTP/protobuf. With the
 feature compiled out, enabling telemetry logs a `warn!` and export is skipped.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,7 +93,7 @@ tasks:
       - cargo run -p ai-powered-client
 
   examples:mcp-server:
-    desc: Run the MCP-enabled A2A server example (set MCP_ENABLE=true and MCP_SERVERS=<urls>; needs Inference Gateway at localhost:8080)
+    desc: Run the MCP-enabled A2A server example (set MCP_ENABLED=true and MCP_SERVERS=<urls>; needs Inference Gateway at localhost:8080)
     dir: examples/mcp/server
     cmds:
       - cargo run -p mcp-server

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ override via `.env` to use any other provider supported by the gateway
 | [`default-handlers/`](./default-handlers) | LLM agent + `with_default_task_handlers()`, no custom handler code |
 | [`ai-powered/`](./ai-powered) | LLM agent with custom function tools (weather, math, search) |
 | [`ai-powered-streaming/`](./ai-powered-streaming) | LLM agent streamed over `message/stream` |
-| [`mcp/`](./mcp) | LLM agent that discovers/invokes MCP tools via `mcp_list_tools` / `mcp_call_tool` selector tools (`MCP_ENABLE`, `MCP_SERVERS`) |
+| [`mcp/`](./mcp) | LLM agent that discovers/invokes MCP tools via `mcp_list_tools` / `mcp_call_tool` selector tools (`MCP_ENABLED`, `MCP_SERVERS`) |
 | [`usage-metadata/`](./usage-metadata) | Default handlers attach token `usage` + `execution_stats` to `task.metadata` on terminal states |
 
 ### Storage & Protocol

--- a/examples/artifacts-filesystem/README.md
+++ b/examples/artifacts-filesystem/README.md
@@ -109,7 +109,7 @@ and assigns the result onto `Config::artifacts_config`:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `ARTIFACTS_ENABLE` | `false` | Master switch for the subsystem. |
+| `ARTIFACTS_ENABLED` | `false` | Master switch for the subsystem. |
 | `ARTIFACTS_SERVER_HOST` | `0.0.0.0` | Bind address of the artifacts HTTP server. |
 | `ARTIFACTS_SERVER_PORT` | `8081` | Port of the artifacts HTTP server. |
 | `ARTIFACTS_STORAGE_PROVIDER` | `filesystem` | `filesystem` or `minio`. |

--- a/examples/artifacts-filesystem/docker-compose.yaml
+++ b/examples/artifacts-filesystem/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - "8088:8088"   # Artifacts HTTP (exposed for host-side curl/debug)
     environment:
       RUST_LOG: info
-      ARTIFACTS_ENABLE: "true"
+      ARTIFACTS_ENABLED: "true"
       ARTIFACTS_SERVER_HOST: "0.0.0.0"
       ARTIFACTS_SERVER_PORT: "8088"
       ARTIFACTS_STORAGE_PROVIDER: filesystem

--- a/examples/artifacts-filesystem/server/main.rs
+++ b/examples/artifacts-filesystem/server/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut artifacts_config = envy::prefixed("ARTIFACTS_")
         .from_env::<ArtifactsConfig>()
         .map_err(|e| format!("failed to load ARTIFACTS_* config: {e}"))?;
-    if env::var_os("ARTIFACTS_ENABLE").is_none() {
+    if env::var_os("ARTIFACTS_ENABLED").is_none() {
         artifacts_config.enable = true;
         artifacts_config.server.port = 8088;
         artifacts_config.storage.base_path = "./artifacts-data".to_string();

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -11,7 +11,7 @@ agent card only to authenticated callers.
   [`AuthVerifier`] into the server. The example uses a static-token
   verifier for the zero-deps quick demo and falls back to the bundled
   `OidcJwtVerifier` (OIDC discovery + JWKS validation) when
-  `AUTH_ENABLE=true` is set.
+  `AUTH_ENABLED=true` is set.
 - `POST /a2a` returns **HTTP 401** when the `Authorization` header is
   missing or malformed.
 - `GET /health` and `GET /.well-known/agent.json` remain reachable
@@ -67,7 +67,7 @@ network:
 1. **Keycloak 26.6.1** - pre-imports `keycloak/realm-export.json` on
    start, so the realm, client, and audience mapper are ready before
    any other service launches.
-2. **`auth-server`** - runs with `AUTH_ENABLE=true` so the
+2. **`auth-server`** - runs with `AUTH_ENABLED=true` so the
    `A2AServerBuilder` instantiates `OidcJwtVerifier` from
    `Config::from_env()` and validates incoming JWTs against the
    Keycloak realm's JWKS.
@@ -139,4 +139,4 @@ exec into the container to reach it from the host).
 3. Otherwise no auth middleware is attached and all routes are public.
 
 The example server picks between (1) and (2) at startup based on the
-`AUTH_ENABLE` env var.
+`AUTH_ENABLED` env var.

--- a/examples/auth/docker-compose.yaml
+++ b/examples/auth/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
         BIN_NAME: auth-server
         EXAMPLE_PATH: examples/auth
     environment:
-      A2A_AUTH_ENABLE: "true"
+      A2A_AUTH_ENABLED: "true"
       A2A_AUTH_ISSUER_URL: http://keycloak:8080/realms/inference-gateway-realm
       A2A_AUTH_CLIENT_ID: inference-gateway-client
       A2A_SERVER_PORT: "8080"

--- a/examples/auth/server/main.rs
+++ b/examples/auth/server/main.rs
@@ -9,7 +9,7 @@
 //!    in-process [`AuthVerifier`] accepts one hard-coded token (set
 //!    via `EXAMPLE_BEARER_TOKEN`). Zero external dependencies.
 //! 2. **OIDC mode** (used by `docker-compose.yaml` against a Keycloak
-//!    realm): set `A2A_AUTH_ENABLE=true`, `A2A_AUTH_ISSUER_URL=...`, and
+//!    realm): set `A2A_AUTH_ENABLED=true`, `A2A_AUTH_ISSUER_URL=...`, and
 //!    `A2A_AUTH_CLIENT_ID=...`. The example loads those through
 //!    `envy::prefixed("A2A_").from_env::<Config>()` and the builder
 //!    instantiates the bundled [`OidcJwtVerifier`] which does OIDC
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // constructs OidcJwtVerifier from `auth_config.issuer_url` /
         // `auth_config.client_id`.
         info!(
-            "A2A_AUTH_ENABLE=true → using OidcJwtVerifier (issuer={})",
+            "A2A_AUTH_ENABLED=true → using OidcJwtVerifier (issuer={})",
             config.auth_config.issuer_url
         );
         builder = builder.with_config(config);
@@ -108,7 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let bearer_token =
             std::env::var("EXAMPLE_BEARER_TOKEN").unwrap_or_else(|_| "demo-token-123".to_string());
         info!(
-            "A2A_AUTH_ENABLE not set → using StaticTokenVerifier (expected token: {bearer_token})"
+            "A2A_AUTH_ENABLED not set → using StaticTokenVerifier (expected token: {bearer_token})"
         );
         let verifier: Arc<dyn AuthVerifier> = Arc::new(StaticTokenVerifier {
             expected: bearer_token,

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -14,7 +14,7 @@ just two *selector* tools regardless of how many tools the servers publish:
 
 ```
 mcp/
-├── server/main.rs                 Agent wired to McpClient behind MCP_ENABLE
+├── server/main.rs                 Agent wired to McpClient behind MCP_ENABLED
 ├── server/.well-known/agent.json  Agent metadata loaded at startup
 ├── client/main.rs                 Two-prompt demo via message/send + poll
 └── README.md
@@ -22,7 +22,7 @@ mcp/
 
 ## What this shows
 
-- **`McpClient::from_config(&McpConfig)`** - returns `None` when `MCP_ENABLE`
+- **`McpClient::from_config(&McpConfig)`** - returns `None` when `MCP_ENABLED`
   is false or `MCP_SERVERS` is empty, so the selector tools are registered
   only when MCP is on.
 - **`McpClient::start()`** - spawns background discovery + refresh. Initial
@@ -36,7 +36,7 @@ mcp/
 
 | Var | Default | Purpose |
 | --- | --- | --- |
-| `MCP_ENABLE` | `false` | Enable the MCP client |
+| `MCP_ENABLED` | `false` | Enable the MCP client |
 | `MCP_SERVERS` | - | Comma-separated MCP server base URLs |
 | `MCP_ENDPOINT` | `/mcp` | Path appended to each server URL |
 | `MCP_REFRESH_INTERVAL` | `5m` | Tool-catalog refresh interval |
@@ -52,7 +52,7 @@ mcp/
 # Start an Inference Gateway and one or more MCP servers separately, then run
 # the server from inside its subdir so .well-known/agent.json resolves:
 cd examples/mcp/server
-export MCP_ENABLE=true
+export MCP_ENABLED=true
 export MCP_SERVERS=http://localhost:3000   # your MCP server base URL(s)
 cargo run -p mcp-server
 # or: task examples:mcp-server
@@ -62,5 +62,5 @@ cargo run -p mcp-client
 ```
 
 The server listens on `0.0.0.0:8086`. The client honours `SERVER_URL`
-(default `http://localhost:8086`). With `MCP_ENABLE` unset the server still
+(default `http://localhost:8086`). With `MCP_ENABLED` unset the server still
 runs - it just has no MCP tools to offer.

--- a/examples/mcp/server/main.rs
+++ b/examples/mcp/server/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             agent_builder = agent_builder.with_mcp_client(client);
             info!("MCP client started; mcp_list_tools / mcp_call_tool registered on the agent");
         }
-        None => info!("MCP disabled - set MCP_ENABLE=true and MCP_SERVERS=<urls> to enable"),
+        None => info!("MCP disabled - set MCP_ENABLED=true and MCP_SERVERS=<urls> to enable"),
     }
 
     let agent = agent_builder.build().await?;

--- a/examples/tls/README.md
+++ b/examples/tls/README.md
@@ -50,7 +50,7 @@ want to rotate them.
 ## Run the server (TLS only)
 
 ```bash
-SERVER_TLS_ENABLE=true \
+SERVER_TLS_ENABLED=true \
 SERVER_TLS_CERT_PATH=examples/tls/certs/server.crt \
 SERVER_TLS_KEY_PATH=examples/tls/certs/server.key \
 PORT=8443 \
@@ -72,7 +72,7 @@ Add `SERVER_TLS_CLIENT_CA_PATH` to require every client to present a
 certificate signed by `ca.crt`:
 
 ```bash
-SERVER_TLS_ENABLE=true \
+SERVER_TLS_ENABLED=true \
 SERVER_TLS_CERT_PATH=examples/tls/certs/server.crt \
 SERVER_TLS_KEY_PATH=examples/tls/certs/server.key \
 SERVER_TLS_CLIENT_CA_PATH=examples/tls/certs/ca.crt \
@@ -133,7 +133,7 @@ cargo run -p tls-client
 
 | Variable | Purpose |
 | --- | --- |
-| `SERVER_TLS_ENABLE` | Required. Set to `true` to flip `A2AServer::serve` onto the TLS listener. |
+| `SERVER_TLS_ENABLED` | Required. Set to `true` to flip `A2AServer::serve` onto the TLS listener. |
 | `SERVER_TLS_CERT_PATH` | PEM file with the server certificate chain. |
 | `SERVER_TLS_KEY_PATH` | PEM file with the server private key (PKCS#1, PKCS#8, or SEC1). |
 | `SERVER_TLS_CLIENT_CA_PATH` | Optional. When set, the server requires mTLS and trusts client certificates signed by any CA in this PEM bundle. |

--- a/examples/tls/docker-compose.yaml
+++ b/examples/tls/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
         BIN_NAME: tls-server
         EXAMPLE_PATH: examples/tls
     environment:
-      A2A_SERVER_TLS_ENABLE: "true"
+      A2A_SERVER_TLS_ENABLED: "true"
       A2A_SERVER_TLS_CERT_PATH: /certs/server.crt
       A2A_SERVER_TLS_KEY_PATH: /certs/server.key
       A2A_SERVER_PORT: "8443"
@@ -63,7 +63,7 @@ services:
         BIN_NAME: tls-server
         EXAMPLE_PATH: examples/tls
     environment:
-      A2A_SERVER_TLS_ENABLE: "true"
+      A2A_SERVER_TLS_ENABLED: "true"
       A2A_SERVER_TLS_CERT_PATH: /certs/server.crt
       A2A_SERVER_TLS_KEY_PATH: /certs/server.key
       A2A_SERVER_TLS_CLIENT_CA_PATH: /certs/ca.crt

--- a/examples/tls/server/main.rs
+++ b/examples/tls/server/main.rs
@@ -20,7 +20,7 @@
 //!
 //! All TLS knobs are picked up via `envy::prefixed("A2A_").from_env::<Config>()`:
 //!
-//! - `A2A_SERVER_TLS_ENABLE=true`
+//! - `A2A_SERVER_TLS_ENABLED=true`
 //! - `A2A_SERVER_TLS_CERT_PATH=/path/to/server.crt`
 //! - `A2A_SERVER_TLS_KEY_PATH=/path/to/server.key`
 //! - `A2A_SERVER_TLS_CLIENT_CA_PATH=/path/to/ca.crt` (optional, mTLS only)
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config: Config = envy::prefixed("A2A_").from_env()?;
     if !config.tls_config.enable {
-        return Err("A2A_SERVER_TLS_ENABLE=true is required to run the tls example".into());
+        return Err("A2A_SERVER_TLS_ENABLED=true is required to run the tls example".into());
     }
     let tls = &config.tls_config;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,7 +371,7 @@ pub struct CapabilitiesConfig {
 #[serde(default)]
 pub struct TlsConfig {
     #[serde(
-        rename = "server_tls_enable",
+        rename = "server_tls_enabled",
         deserialize_with = "de::boolean::deserialize"
     )]
     pub enable: bool,
@@ -394,7 +394,7 @@ pub struct TlsConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AuthConfig {
-    #[serde(rename = "auth_enable", deserialize_with = "de::boolean::deserialize")]
+    #[serde(rename = "auth_enabled", deserialize_with = "de::boolean::deserialize")]
     pub enable: bool,
 
     #[serde(rename = "auth_issuer_url")]
@@ -490,7 +490,7 @@ impl FromStr for TracesExporter {
 #[serde(default)]
 pub struct TelemetryConfig {
     #[serde(
-        rename = "telemetry_enable",
+        rename = "telemetry_enabled",
         deserialize_with = "de::boolean::deserialize"
     )]
     pub enable: bool,
@@ -507,7 +507,7 @@ pub struct TelemetryConfig {
 impl TelemetryConfig {
     /// Single gate for trace export: traces are active when telemetry is
     /// enabled AND the traces exporter is not `none`. Mirrors the Go ADK,
-    /// where `A2A_TELEMETRY_ENABLE` is the sole telemetry switch and
+    /// where `A2A_TELEMETRY_ENABLED` is the sole telemetry switch and
     /// `A2A_OTEL_TRACES_EXPORTER=none` opts the trace signal out.
     pub fn traces_enabled(&self) -> bool {
         self.enable && self.traces_exporter != TracesExporter::None
@@ -531,8 +531,8 @@ impl TelemetryConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct McpConfig {
-    /// Master switch. `MCP_ENABLE`.
-    #[serde(rename = "enable", deserialize_with = "de::boolean::deserialize")]
+    /// Master switch. `MCP_ENABLED`.
+    #[serde(rename = "enabled", deserialize_with = "de::boolean::deserialize")]
     pub enable: bool,
 
     /// Comma-separated MCP server base URLs. `MCP_SERVERS`.
@@ -609,7 +609,7 @@ impl Default for McpConfig {
 pub struct ArtifactsConfig {
     /// Whether the artifacts server should be started when
     /// [`A2AServer::serve`](crate::A2AServer::serve) runs.
-    #[serde(deserialize_with = "de::boolean::deserialize")]
+    #[serde(rename = "enabled", deserialize_with = "de::boolean::deserialize")]
     pub enable: bool,
 
     #[serde(flatten)]
@@ -883,7 +883,7 @@ mod tests {
     #[test]
     fn artifacts_config_loads_full_env_surface() {
         let cfg = load(&[
-            ("ARTIFACTS_ENABLE", "true"),
+            ("ARTIFACTS_ENABLED", "true"),
             ("ARTIFACTS_SERVER_HOST", "127.0.0.1"),
             ("ARTIFACTS_SERVER_PORT", "9099"),
             ("ARTIFACTS_STORAGE_PROVIDER", "minio"),
@@ -914,7 +914,7 @@ mod tests {
 
     #[test]
     fn artifacts_config_partial_env_falls_back_to_defaults() {
-        let cfg = load(&[("ARTIFACTS_ENABLE", "1")]);
+        let cfg = load(&[("ARTIFACTS_ENABLED", "1")]);
         assert!(cfg.enable);
         // Unset leaves keep ArtifactsConfig defaults (Go-matching).
         assert_eq!(cfg.server.port, 8081);
@@ -978,7 +978,7 @@ mod tests {
         // never touches it - it stays at the programmatic default.
         let config: Config = envy::prefixed("A2A_")
             .from_iter::<_, Config>(vec![(
-                "A2A_ARTIFACTS_ENABLE".to_string(),
+                "A2A_ARTIFACTS_ENABLED".to_string(),
                 "true".to_string(),
             )])
             .expect("Config should load");
@@ -997,7 +997,7 @@ mod tests {
 
     #[test]
     fn telemetry_traces_default_to_otlp_and_gate_on_enable() {
-        // Single gate: A2A_TELEMETRY_ENABLE + exporter != none.
+        // Single gate: A2A_TELEMETRY_ENABLED + exporter != none.
         let table = [
             // (enable, exporter, expected traces_enabled)
             (None, None, false),                  // disabled by default
@@ -1010,7 +1010,7 @@ mod tests {
         for (enable, exporter, expected) in table {
             let mut vars = Vec::new();
             if let Some(e) = enable {
-                vars.push(("A2A_TELEMETRY_ENABLE", e));
+                vars.push(("A2A_TELEMETRY_ENABLED", e));
             }
             if let Some(x) = exporter {
                 vars.push(("A2A_OTEL_TRACES_EXPORTER", x));
@@ -1065,7 +1065,7 @@ mod tests {
     #[test]
     fn mcp_config_loads_env_surface() {
         let cfg = load_mcp(&[
-            ("MCP_ENABLE", "true"),
+            ("MCP_ENABLED", "true"),
             ("MCP_SERVERS", "http://a:3000,http://b:3000"),
             ("MCP_ENDPOINT", "/rpc"),
             ("MCP_REFRESH_INTERVAL", "10m"),

--- a/src/server/artifact_service.rs
+++ b/src/server/artifact_service.rs
@@ -11,7 +11,7 @@
 //!
 //! The default implementation - [`DefaultArtifactService`] - is the one
 //! the [`A2AServerBuilder`] wires up automatically when
-//! `ARTIFACTS_ENABLE=true`.
+//! `ARTIFACTS_ENABLED=true`.
 //!
 //! [`A2AServerBuilder`]: super::server_builder::A2AServerBuilder
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -184,7 +184,9 @@ impl OidcJwtVerifier {
     /// 5s timeout for discovery + JWKS fetches.
     pub fn from_config(config: &AuthConfig) -> Result<Self> {
         if config.issuer_url.trim().is_empty() {
-            return Err(anyhow!("AUTH_ISSUER_URL is required when AUTH_ENABLE=true"));
+            return Err(anyhow!(
+                "AUTH_ISSUER_URL is required when AUTH_ENABLED=true"
+            ));
         }
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -92,7 +92,7 @@ impl McpClient {
             .filter(|s| !s.is_empty())
             .collect();
         if bases.is_empty() {
-            warn!("MCP_ENABLE is set but MCP_SERVERS is empty; MCP client not started");
+            warn!("MCP_ENABLED is set but MCP_SERVERS is empty; MCP client not started");
             return None;
         }
 

--- a/src/server/server_core.rs
+++ b/src/server/server_core.rs
@@ -135,7 +135,7 @@ fn spawn_artifacts_subsystem(
     let Some(service) = artifact_service else {
         if artifacts_config.enable {
             warn!(
-                "ARTIFACTS_ENABLE=true but no artifact service is configured; skipping \
+                "ARTIFACTS_ENABLED=true but no artifact service is configured; skipping \
                  artifacts server startup"
             );
         }

--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -133,12 +133,12 @@ pub(crate) fn build_server_config(tls: &TlsConfig) -> Result<Arc<RustlsServerCon
 
     if tls.cert_path.trim().is_empty() {
         return Err(anyhow!(
-            "SERVER_TLS_CERT_PATH is required when SERVER_TLS_ENABLE=true"
+            "SERVER_TLS_CERT_PATH is required when SERVER_TLS_ENABLED=true"
         ));
     }
     if tls.key_path.trim().is_empty() {
         return Err(anyhow!(
-            "SERVER_TLS_KEY_PATH is required when SERVER_TLS_ENABLE=true"
+            "SERVER_TLS_KEY_PATH is required when SERVER_TLS_ENABLED=true"
         ));
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -96,7 +96,7 @@ pub fn init(
     #[cfg(not(feature = "telemetry"))]
     if cfg.traces_enabled() {
         tracing::warn!(
-            "A2A_TELEMETRY_ENABLE=true but the `telemetry` Cargo feature is not compiled in; \
+            "A2A_TELEMETRY_ENABLED=true but the `telemetry` Cargo feature is not compiled in; \
              spans will not be exported. Rebuild with `--features telemetry`."
         );
     }

--- a/tests/tls_test.rs
+++ b/tests/tls_test.rs
@@ -4,7 +4,7 @@
 //! TLS handshake from the test process using `tokio_rustls`, and asserts
 //! that the round-trip produces the expected behaviour:
 //!
-//! - `tls_terminates_on_https_listener` proves that `SERVER_TLS_ENABLE=true`
+//! - `tls_terminates_on_https_listener` proves that `SERVER_TLS_ENABLED=true`
 //!   with a cert/key pair actually serves traffic over TLS (no client
 //!   cert required) and that `/health` is reachable.
 //! - `mtls_handshake_with_valid_client_cert_succeeds` proves that


### PR DESCRIPTION
## Summary

Renames every enable-flag env var to the `*_ENABLED` form the Go ADK uses and that adl-cli's generated `.env.example` / `docker-compose.yaml` already document:

| Before | After |
| --- | --- |
| `A2A_AUTH_ENABLE` | `A2A_AUTH_ENABLED` |
| `A2A_SERVER_TLS_ENABLE` | `A2A_SERVER_TLS_ENABLED` |
| `A2A_TELEMETRY_ENABLE` | `A2A_TELEMETRY_ENABLED` |
| `MCP_ENABLE` | `MCP_ENABLED` |
| `ARTIFACTS_ENABLE` | `ARTIFACTS_ENABLED` |

## Why

An operator following the generated docs and setting `A2A_AUTH_ENABLED=true` was silently ignored: the flag stayed `false`, no verifier was built, and `POST /a2a` served unauthenticated. This is the same silent fail-open class the Go ADK fixed in v0.26.4 (inference-gateway/adk#282), relocated to the env-naming layer. Artifacts had the same mismatch (`A2A_ARTIFACTS_ENABLED` in generated compose vs `ARTIFACTS_ENABLE` here).

Per maintainer decision there are **no aliases for the old names** — deployments using `*_ENABLE` must rename the vars.

## Changes

- `src/config.rs`: serde renames for `AuthConfig`, `TlsConfig`, `TelemetryConfig`, `McpConfig`, `ArtifactsConfig` (internal field names unchanged)
- Error/log messages, README, CLAUDE.md, examples (auth, tls, mcp, artifacts) and tests updated to the new names

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features` all pass on rustc 1.95.0; the config tests exercise the new names end-to-end

## Cross-repo impact

- **adl-cli**: no change needed — its templates already emit `A2A_AUTH_ENABLED` / `A2A_ARTIFACTS_ENABLED`, which this PR makes correct for Rust agents
- **typescript-adk**: worth the same audit for `*_ENABLE` drift
- **docs**: any pages mentioning the Rust env vars need the new names once this lands