### PR TITLE
fix(auth): require full OIDC config and always validate the JWT audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,8 +1136,8 @@ configured by `A2A_AUTH_ISSUER_URL`. The bundled `OidcJwtVerifier`:
 
 1. Performs OIDC discovery at `<A2A_AUTH_ISSUER_URL>/.well-known/openid-configuration`.
 2. Fetches and caches the JWKS advertised by the discovery document.
-3. Validates the JWT signature, `iss`, `exp`, and (when `A2A_AUTH_CLIENT_ID`
-   is set) `aud` claims.
+3. Validates the JWT signature, `iss`, `exp`, and `aud` (against
+   `A2A_AUTH_CLIENT_ID`) claims.
 
 `GET /health` and `GET /.well-known/agent.json` are always public so
 health probes and discovery clients keep working without a credential.
@@ -1397,8 +1397,8 @@ A2A_QUEUE_WORKERS="1"
 # Authentication (optional, OIDC bearer-token JWT)
 A2A_AUTH_ENABLED="false"                                                   # when true, POST /a2a requires a valid bearer token
 A2A_AUTH_ISSUER_URL="http://keycloak:8080/realms/inference-gateway-realm" # OIDC issuer; the server performs discovery + JWKS lookup
-A2A_AUTH_CLIENT_ID="inference-gateway-client"                             # validated as the JWT audience when set
-A2A_AUTH_CLIENT_SECRET="your-secret"                                      # currently unused server-side (reserved for client-side OAuth2)
+A2A_AUTH_CLIENT_ID="inference-gateway-client"                             # required; validated as the JWT audience
+A2A_AUTH_CLIENT_SECRET="your-secret"                                      # required; not used for JWT verification (reserved for client-side OAuth2)
 
 # TLS (optional)
 A2A_SERVER_TLS_ENABLED="false"                   # when true, A2AServer::serve binds an HTTPS listener via axum-server + rustls

--- a/examples/auth/docker-compose.yaml
+++ b/examples/auth/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
       A2A_AUTH_ENABLED: "true"
       A2A_AUTH_ISSUER_URL: http://keycloak:8080/realms/inference-gateway-realm
       A2A_AUTH_CLIENT_ID: inference-gateway-client
+      A2A_AUTH_CLIENT_SECRET: inference-gateway-client-secret
       A2A_SERVER_PORT: "8080"
     depends_on:
       keycloak:

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -153,11 +153,11 @@ pub trait AuthVerifier: Send + Sync + std::fmt::Debug {
 
 /// JWT verifier that pulls the JWKS from an OIDC issuer's discovery
 /// document and caches the keys in memory. Verifies token signature,
-/// `iss`, `exp`, and (when `client_id` is configured) `aud`.
+/// `iss`, `exp`, and `aud` (against `client_id`).
 #[derive(Debug)]
 pub struct OidcJwtVerifier {
     issuer_url: String,
-    audience: Option<String>,
+    audience: String,
     http: reqwest::Client,
     cache: RwLock<JwksCache>,
 }
@@ -183,23 +183,22 @@ impl OidcJwtVerifier {
     /// Build a verifier from the [`AuthConfig`]. The HTTP client uses a
     /// 5s timeout for discovery + JWKS fetches.
     pub fn from_config(config: &AuthConfig) -> Result<Self> {
-        if config.issuer_url.trim().is_empty() {
+        if config.issuer_url.trim().is_empty()
+            || config.client_id.trim().is_empty()
+            || config.client_secret.trim().is_empty()
+        {
             return Err(anyhow!(
-                "AUTH_ISSUER_URL is required when AUTH_ENABLED=true"
+                "AUTH_ISSUER_URL, AUTH_CLIENT_ID, and AUTH_CLIENT_SECRET are required when \
+                 AUTH_ENABLED=true"
             ));
         }
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
             .build()
             .map_err(|e| anyhow!("failed to build OIDC HTTP client: {e}"))?;
-        let audience = if config.client_id.trim().is_empty() {
-            None
-        } else {
-            Some(config.client_id.clone())
-        };
         Ok(Self {
             issuer_url: config.issuer_url.trim_end_matches('/').to_string(),
-            audience,
+            audience: config.client_id.clone(),
             http,
             cache: RwLock::new(JwksCache::default()),
         })
@@ -318,11 +317,7 @@ impl AuthVerifier for OidcJwtVerifier {
 
         let mut validation = Validation::new(alg);
         validation.set_issuer(&[self.issuer_url.as_str()]);
-        if let Some(aud) = self.audience.as_ref() {
-            validation.set_audience(&[aud.as_str()]);
-        } else {
-            validation.validate_aud = false;
-        }
+        validation.set_audience(&[self.audience.as_str()]);
 
         let data = decode::<HashMap<String, Value>>(token, &decoding, &validation)
             .map_err(|e| AuthError::InvalidToken(e.to_string()))?;
@@ -478,5 +473,23 @@ mod tests {
         };
         let err = OidcJwtVerifier::from_config(&cfg).expect_err("issuer required");
         assert!(err.to_string().contains("AUTH_ISSUER_URL"));
+    }
+
+    #[test]
+    fn from_config_requires_client_id_and_secret() {
+        let mut cfg = AuthConfig {
+            enable: true,
+            issuer_url: "https://issuer.test".to_string(),
+            client_id: String::new(),
+            client_secret: "secret".to_string(),
+        };
+        OidcJwtVerifier::from_config(&cfg).expect_err("client id required");
+
+        cfg.client_id = "client".to_string();
+        cfg.client_secret = String::new();
+        OidcJwtVerifier::from_config(&cfg).expect_err("client secret required");
+
+        cfg.client_secret = "secret".to_string();
+        OidcJwtVerifier::from_config(&cfg).expect("complete config builds");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #134, aligning `OidcJwtVerifier::from_config` with the Go ADK (since v0.26.4, inference-gateway/adk#282) and the TypeScript ADK, which both require issuer URL, client id, and client secret when auth is enabled.

## Why

Previously only `A2A_AUTH_ISSUER_URL` was required; an empty `A2A_AUTH_CLIENT_ID` silently disabled audience validation, so any valid token from the issuer was accepted regardless of which client it was minted for. `A2A_AUTH_CLIENT_SECRET` existed in `AuthConfig` but was never read, implying validation that wasn't happening.

## Changes

- `from_config` errors when `AUTH_CLIENT_ID` or `AUTH_CLIENT_SECRET` is missing (in addition to the existing issuer check)
- `audience` is now a required `String` and `aud` is always validated
- `client_secret` is not used for JWT verification (reserved for client-side OAuth2 flows) but is required for cross-ADK config parity — noted in the README
- auth example compose gains `A2A_AUTH_CLIENT_SECRET` so it still boots
- new test covering the missing-client-id / missing-secret / complete-config cases

## Verification

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features` all pass on rustc 1.95.0

## Cross-repo impact

- **adl-cli**: none — generated `.env.example` already lists all three vars
- **docs**: auth pages should state all three vars are required for Rust agents once this lands